### PR TITLE
Fix settings UI startup race so window loads reliably

### DIFF
--- a/settings_ui.py
+++ b/settings_ui.py
@@ -946,9 +946,24 @@ HTML_TEMPLATE = """<!DOCTYPE html>
     }
   }
 
+  function apiReady() {
+    return !!(window.pywebview && window.pywebview.api);
+  }
+
+  async function waitForApi(timeoutMs = 7000) {
+    const start = Date.now();
+    while (!apiReady()) {
+      if ((Date.now() - start) > timeoutMs) {
+        throw new Error('Timed out waiting for app bridge.');
+      }
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    }
+  }
+
   async function init() {
     applyConfig(BOOTSTRAP_CONFIG);
     try {
+      await waitForApi();
       const cfg = await pywebview.api.get_config();
       applyConfig(cfg);
       hideSettingsStatus();
@@ -1001,7 +1016,10 @@ HTML_TEMPLATE = """<!DOCTYPE html>
     btn.textContent = '\u2191 Check for Updates';
   }
 
-  document.addEventListener('DOMContentLoaded', () => applyConfig(BOOTSTRAP_CONFIG));
+  document.addEventListener('DOMContentLoaded', () => {
+    applyConfig(BOOTSTRAP_CONFIG);
+    init();
+  });
   window.addEventListener('pywebviewready', init);
 </script>
 </body>


### PR DESCRIPTION
### Motivation
- The settings webview could initialize before the `pywebview` JS bridge was attached, leaving the UI partially broken or unable to call back into the app. 
- The goal is to make the page reliably obtain runtime config from the app bridge regardless of event ordering differences across environments.

### Description
- Added an `apiReady()` helper and a `waitForApi(timeoutMs)` loop that waits for `window.pywebview.api` to be present before using it. 
- Call `await waitForApi()` in `init()` before invoking `pywebview.api.get_config()` to avoid race conditions. 
- Start initialization from `DOMContentLoaded` (while retaining the `pywebviewready` listener) so the page applies the bootstrap snapshot immediately and then upgrades when the bridge is ready. 
- Kept existing behavior for applying the bootstrap config and handling failures, only adding a deterministic bridge readiness step.

### Testing
- Ran `python -m py_compile settings_ui.py` which succeeded. 
- Ran `python -m py_compile settings_ui.py main.py diagnostics_ui.py` earlier in the session which also succeeded. 
- Ran `python self_tests.py` which failed in this Linux container due to the platform-specific `winreg` import (Windows-only), so full runtime integration tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46f7f3b34832ea712af58321ac47b)