### PR TITLE
Fix song picker corrections

### DIFF
--- a/album_art.py
+++ b/album_art.py
@@ -1,5 +1,6 @@
 # MIT License - Copyright (c) 2026 eripum9
 
+import os
 import requests
 from urllib.parse import quote
 
@@ -14,8 +15,17 @@ def _clean_title(title):
     return title.strip()
 
 
-def search_tracks(query, limit=5):
-    url = f"https://api.deezer.com/search?q={quote(query)}&limit={limit}"
+def _bounded_int(value, default, minimum=0):
+    try:
+        return max(minimum, int(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def search_tracks(query, limit=5, offset=0):
+    limit = _bounded_int(limit, 5, 1)
+    offset = _bounded_int(offset, 0, 0)
+    url = f"https://api.deezer.com/search?q={quote(query)}&limit={limit}&index={offset}"
     try:
         resp = requests.get(url, timeout=5)
         resp.raise_for_status()
@@ -29,19 +39,22 @@ def search_tracks(query, limit=5):
                 "artist": track.get("artist", {}).get("name", ""),
                 "album": album.get("title", ""),
                 "art_url": art or "",
+                "track_link": track.get("link", ""),
+                "duration": track.get("duration", 0) or 0,
             })
         if results:
             return results
     except (requests.RequestException, KeyError, ValueError):
         pass
 
-    url = f"https://itunes.apple.com/search?term={quote(query)}&media=music&limit={limit}"
+    fetch_limit = min(max(limit + offset, limit), 200)
+    url = f"https://itunes.apple.com/search?term={quote(query)}&media=music&limit={fetch_limit}"
     try:
         resp = requests.get(url, timeout=5)
         resp.raise_for_status()
         data = resp.json()
         results = []
-        for r in data.get("results", []):
+        for r in data.get("results", [])[offset:offset + limit]:
             art_url = r.get("artworkUrl100", "")
             if art_url:
                 art_url = art_url.replace("100x100bb", "600x600bb")
@@ -50,11 +63,55 @@ def search_tracks(query, limit=5):
                 "artist": r.get("artistName", ""),
                 "album": r.get("collectionName", ""),
                 "art_url": art_url,
+                "track_link": r.get("trackViewUrl", ""),
+                "duration": round((r.get("trackTimeMillis") or 0) / 1000),
             })
         return results
     except (requests.RequestException, KeyError, ValueError):
         pass
     return []
+
+
+def _normalise_name(value):
+    return " ".join(str(value or "").strip().lower().split())
+
+
+def _split_aliases(value):
+    if isinstance(value, list):
+        items = value
+    else:
+        items = str(value or "").replace("\n", ",").split(",")
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _normalise_art_value(value):
+    art = str(value or "").strip()
+    if not art:
+        return ""
+    if art.lower().startswith(("http://", "https://", "mp:", "file://")):
+        return art
+    if os.path.exists(art):
+        return os.path.abspath(art)
+    return art
+
+
+def find_custom_album_art(config, *album_names):
+    entries = config.get("custom_albums", [])
+    if not isinstance(entries, list):
+        return None
+    candidates = {_normalise_name(name) for name in album_names if _normalise_name(name)}
+    if not candidates:
+        return None
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        album = str(entry.get("album", "")).strip()
+        art_url = _normalise_art_value(entry.get("art_url", ""))
+        names = [album] + _split_aliases(entry.get("aliases", []))
+        normalised = {_normalise_name(name) for name in names if _normalise_name(name)}
+        if art_url and candidates.intersection(normalised):
+            return {"album": album or next(iter(candidates)), "art_url": art_url}
+    return None
 
 
 def _search_deezer(title, artist):

--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ if not os.environ.get("APPDATA") or getattr(sys, "frozen", False) is False:
     CONFIG_DIR = os.path.dirname(os.path.abspath(__file__))
     CONFIG_PATH = os.path.join(CONFIG_DIR, "config.json")
 
-APP_VERSION = "2.2.2"
+APP_VERSION = "2.2.3"
 
 DEFAULTS = {
     "discord_client_id": DEFAULT_CLIENT_ID,
@@ -23,6 +23,7 @@ DEFAULTS = {
     "start_on_startup": False,
     "start_minimized": True,
     "track_mappings": {},
+    "custom_albums": [],
     "song_link_enabled": False,
     "show_paused": True,
     "lastfm_enabled": False,

--- a/installer.iss
+++ b/installer.iss
@@ -1,5 +1,5 @@
 #define MyAppName "Amazon Music RPC"
-#define MyAppVersion "2.2.2"
+#define MyAppVersion "2.2.3"
 #define MyAppPublisher "PumpgunStudios"
 #define MyAppExeName "AmazonMusicRPC.exe"
 

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ import pystray
 
 from media_reader import get_track_sync
 from notification_reader import get_notification_track_sync, is_new_notification
-from album_art import get_album_art, search_tracks
+from album_art import get_album_art, search_tracks, find_custom_album_art
 from discord_rpc import DiscordRPC
 from config import load_config, save_config, get_exe_path, DEFAULT_CLIENT_ID, CONFIG_PATH, APP_VERSION
 from updater import check_for_update, prompt_for_update
@@ -48,7 +48,9 @@ diagnostics_proc = None
 _picker_lock = threading.Lock()
 _picker_pending_key = None
 _resolved_cache = {}
+_resolved_track_info = {}
 _skipped_keys = set()
+_wrong_song_prompted_keys = set()
 _current_track_raw = None
 active_rpc = None
 _track_timing_cache = {}
@@ -57,6 +59,7 @@ RPC_CONFIG_KEYS = {
     "discord_client_id",
     "use_custom_client_id",
     "track_mappings",
+    "custom_albums",
     "song_link_enabled",
     "show_paused",
     "lastfm_enabled",
@@ -105,6 +108,127 @@ def _privacy_match(config, title="", artist="", album=""):
         if keyword in haystack:
             return f"Matched privacy keyword: {keyword}"
     return ""
+
+
+def _normalised_text(value):
+    return " ".join(str(value or "").strip().lower().split())
+
+
+def _same_track_field(left, right):
+    left = _normalised_text(left)
+    right = _normalised_text(right)
+    return bool(left and right and left == right)
+
+
+def _duration_value(value):
+    try:
+        return max(0, int(float(value or 0)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _track_info_payload(track):
+    return {
+        "title": track.get("title", ""),
+        "artist": track.get("artist", ""),
+        "album": track.get("album", ""),
+        "art_url": track.get("art_url", ""),
+        "track_link": track.get("track_link", ""),
+        "duration": _duration_value(track.get("duration", 0)),
+    }
+
+
+def _store_resolved_track(raw_key, track):
+    if not isinstance(track, dict):
+        return
+    payload = _track_info_payload(track)
+    if raw_key:
+        _resolved_track_info[raw_key] = payload
+    resolved_key = f"{payload['title']}|{payload['artist']}"
+    if payload["title"] or payload["artist"]:
+        _resolved_track_info[resolved_key] = payload
+
+
+def _apply_custom_album_override(config, art_url, album_name, *album_names):
+    custom = find_custom_album_art(config, album_name, *album_names)
+    if custom:
+        return custom.get("art_url", art_url), custom.get("album", album_name) or album_name
+    return art_url, album_name
+
+
+def _apply_resolved_cache(raw_key, title, artist):
+    resolved = _resolved_cache.get(raw_key)
+    if not resolved:
+        return title, artist, False
+    return resolved[0] or title, resolved[1] or artist, True
+
+
+def _resolved_art(raw_key, title, artist, fallback_album=""):
+    info = _resolved_track_info.get(raw_key) or _resolved_track_info.get(f"{title}|{artist}")
+    if not info or not info.get("art_url"):
+        return None
+    return (
+        info.get("art_url", ""),
+        info.get("album", "") or fallback_album,
+        info.get("track_link", ""),
+        _duration_value(info.get("duration", 0)),
+    )
+
+
+def _apply_wrong_song_choice(choice, raw_key, title, artist, config):
+    if not choice:
+        return
+    _resolved_cache.pop(raw_key, None)
+    _resolved_track_info.pop(raw_key, None)
+    _skipped_keys.discard(raw_key)
+    if choice == "artist":
+        if not title:
+            return
+        mappings = config.get("track_mappings", {})
+        mappings.pop(title.lower().strip(), None)
+        _resolve_missing_artist(title, "", config, raw_key)
+    elif choice == "title":
+        if not artist:
+            return
+        _resolve_missing_title("", artist, raw_key)
+
+
+def _prompt_wrong_song_async(raw_key, title, artist, config, force=False):
+    global _picker_pending_key
+    if not force and raw_key in _wrong_song_prompted_keys:
+        return
+    with _picker_lock:
+        if _picker_pending_key is not None:
+            return
+        _picker_pending_key = raw_key
+    _wrong_song_prompted_keys.add(raw_key)
+
+    def _worker():
+        global _picker_pending_key
+        response = {}
+        try:
+            tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8")
+            json.dump({"mode": "wrongsong"}, tmp)
+            tmp.close()
+
+            if getattr(sys, 'frozen', False):
+                cmd = [sys.executable, '--picker', tmp.name]
+            else:
+                cmd = [sys.executable, os.path.join(SCRIPT_DIR, "track_picker.py"), tmp.name]
+
+            subprocess.run(cmd, timeout=60)
+
+            with open(tmp.name, "r", encoding="utf-8") as f:
+                response = json.load(f)
+            os.unlink(tmp.name)
+        except Exception as e:
+            print(f"[WrongSong] Error: {e}")
+        finally:
+            with _picker_lock:
+                _picker_pending_key = None
+        _apply_wrong_song_choice(response.get("choice"), raw_key, title, artist, config)
+
+    threading.Thread(target=_worker, daemon=True).start()
 
 
 def _cached_start_ts(raw_key):
@@ -199,6 +323,7 @@ def _run_picker_async(request_data, raw_key, callback):
 
     def _worker():
         global _picker_pending_key
+        response = None
         try:
             tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8")
             json.dump(request_data, tmp)
@@ -214,12 +339,13 @@ def _run_picker_async(request_data, raw_key, callback):
             with open(tmp.name, "r", encoding="utf-8") as f:
                 response = json.load(f)
             os.unlink(tmp.name)
-            callback(response)
         except Exception as e:
             print(f"[Picker] Error: {e}")
         finally:
             with _picker_lock:
                 _picker_pending_key = None
+        if response is not None:
+            callback(response)
 
     threading.Thread(target=_worker, daemon=True).start()
 
@@ -237,6 +363,7 @@ def _resolve_missing_artist(title, artist, config, raw_key):
         m = mappings[mapping_key]
         result = (m.get("title", title), m.get("artist", ""))
         _resolved_cache[raw_key] = result
+        _store_resolved_track(raw_key, m)
         return result
 
     with _picker_lock:
@@ -249,17 +376,28 @@ def _resolve_missing_artist(title, artist, config, raw_key):
         return title, ""
 
     def _on_result(result):
-        if not result or result.get("index", -1) < 0:
+        if not result:
             _skipped_keys.add(raw_key)
             return
-        chosen = choices[result["index"]]
+        chosen = result.get("track")
+        if not chosen:
+            index = result.get("index", -1)
+            if index < 0 or index >= len(choices):
+                _skipped_keys.add(raw_key)
+                return
+            chosen = choices[index]
         _resolved_cache[raw_key] = (chosen["title"], chosen["artist"])
+        _store_resolved_track(raw_key, chosen)
         if result.get("remember"):
-            mappings[mapping_key] = {"title": chosen["title"], "artist": chosen["artist"]}
+            mappings[mapping_key] = _track_info_payload(chosen)
             config["track_mappings"] = mappings
             save_config(config)
 
-    _run_picker_async({"mode": "choice", "title": title, "choices": choices}, raw_key, _on_result)
+    _run_picker_async(
+        {"mode": "choice", "title": title, "choices": choices, "search_query": title, "page_size": 5},
+        raw_key,
+        _on_result,
+    )
     return title, artist
 
 
@@ -277,6 +415,7 @@ def _resolve_missing_title(title, artist, raw_key):
     def _on_result(result):
         if result and result.get("title"):
             _resolved_cache[raw_key] = (result["title"], result.get("artist", artist))
+            _store_resolved_track(raw_key, result)
         else:
             _skipped_keys.add(raw_key)
 
@@ -508,6 +647,10 @@ def rpc_loop():
             artist = track["artist"]
             raw_key = f"{title}|{artist}"
 
+            title, artist, resolved_applied = _apply_resolved_cache(raw_key, title, artist)
+            if not resolved_applied and _same_track_field(title, artist):
+                _prompt_wrong_song_async(raw_key, title, artist, config)
+
             if title and not artist:
                 title, artist = _resolve_missing_artist(title, artist, config, raw_key)
 
@@ -573,11 +716,18 @@ def rpc_loop():
                 _current_notif_data = None
                 _notif_art_fetched_for = None
 
-                last_art_url, last_album_name, last_track_link, last_deezer_duration = get_album_art(title, artist)
+                resolved = _resolved_art(raw_key, title, artist, track.get("album", ""))
+                if resolved:
+                    last_art_url, last_album_name, last_track_link, last_deezer_duration = resolved
+                else:
+                    last_art_url, last_album_name, last_track_link, last_deezer_duration = get_album_art(title, artist)
                 if _notif_album:
                     last_album_name = _notif_album
                 elif not last_album_name and track["album"]:
                     last_album_name = track["album"]
+                last_art_url, last_album_name = _apply_custom_album_override(
+                    config, last_art_url, last_album_name, _notif_album, track.get("album", "")
+                )
                 last_start_ts = _track_start_ts(track, raw_key)
                 if last_art_url:
                     print(f"[Art] Found: '{last_album_name}' for '{title}'")
@@ -604,11 +754,18 @@ def rpc_loop():
                             except Exception:
                                 pass
             elif raw_key in _resolved_cache and last_art_fetch_key != track_art_key:
-                last_art_url, last_album_name, last_track_link, last_deezer_duration = get_album_art(title, artist)
+                resolved = _resolved_art(raw_key, title, artist, track.get("album", ""))
+                if resolved:
+                    last_art_url, last_album_name, last_track_link, last_deezer_duration = resolved
+                else:
+                    last_art_url, last_album_name, last_track_link, last_deezer_duration = get_album_art(title, artist)
                 if _notif_album:
                     last_album_name = _notif_album
                 elif not last_album_name and track["album"]:
                     last_album_name = track["album"]
+                last_art_url, last_album_name = _apply_custom_album_override(
+                    config, last_art_url, last_album_name, _notif_album, track.get("album", "")
+                )
                 last_art_fetch_key = track_art_key
                 print(f"[Art] Refreshed after resolve: '{last_album_name}' for '{title}'")
                 if (scrobbler or lb_scrobbler) and scrobble_start_time and not scrobbled:
@@ -646,6 +803,9 @@ def rpc_loop():
                             last_deezer_duration = _notif_dur
                         print(f"[Art] Re-fetched art for notification album: '{_notif_album}'")
                     _notif_art_fetched_for = notif_art_key
+            last_art_url, last_album_name = _apply_custom_album_override(
+                config, last_art_url, last_album_name, _notif_album, track.get("album", "")
+            )
 
             buttons = None
             if song_link_enabled and last_track_link:
@@ -842,47 +1002,12 @@ def wrong_song_handler(icon=None, item=None):
         return
 
     def _worker():
-        global _current_track_raw
         try:
-            tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8")
-            json.dump({"mode": "wrongsong"}, tmp)
-            tmp.close()
-
-            if getattr(sys, 'frozen', False):
-                cmd = [sys.executable, '--picker', tmp.name]
-            else:
-                cmd = [sys.executable, os.path.join(SCRIPT_DIR, "track_picker.py"), tmp.name]
-
-            subprocess.run(cmd, timeout=60)
-
-            with open(tmp.name, "r", encoding="utf-8") as f:
-                response = json.load(f)
-            os.unlink(tmp.name)
-
-            choice = response.get("choice")
-            if not choice:
-                return
-
-            rk = _current_track_raw or raw_key
-            _resolved_cache.pop(rk, None)
-            _skipped_keys.discard(rk)
-
             track = get_track_sync()
             if not track:
                 return
-
-            if choice == "artist":
-                title = track["title"]
-                if not title:
-                    return
-                mappings = current_config.get("track_mappings", {})
-                mappings.pop(title.lower().strip(), None)
-                _resolve_missing_artist(title, "", current_config, rk)
-            elif choice == "title":
-                artist = track["artist"]
-                if not artist:
-                    return
-                _resolve_missing_title("", artist, rk)
+            rk = _current_track_raw or raw_key
+            _prompt_wrong_song_async(rk, track["title"], track["artist"], current_config, force=True)
         except Exception as e:
             print(f"[WrongSong] Error: {e}")
 

--- a/self_tests.py
+++ b/self_tests.py
@@ -75,6 +75,44 @@ def run_self_tests(log_dir, diagnostics_path):
         results.append(_result("Metadata cleanup", False, str(e)))
 
     try:
+        import inspect
+        from album_art import search_tracks
+        params = inspect.signature(search_tracks).parameters
+        ok = "offset" in params
+        results.append(_result("Paged search", ok, "search_tracks accepts offset"))
+    except Exception as e:
+        results.append(_result("Paged search", False, str(e)))
+
+    try:
+        from album_art import find_custom_album_art
+        custom = find_custom_album_art(
+            {
+                "custom_albums": [
+                    {
+                        "album": "Correct Album",
+                        "aliases": ["Wrong Album", "Alt Album"],
+                        "art_url": "https://example.com/cover.jpg",
+                    }
+                ]
+            },
+            "wrong album",
+        )
+        ok = bool(custom) and custom["album"] == "Correct Album" and custom["art_url"].endswith("cover.jpg")
+        results.append(_result("Custom album art", ok, "Album aliases match custom artwork"))
+    except Exception as e:
+        results.append(_result("Custom album art", False, str(e)))
+
+    try:
+        import main
+        main._resolved_cache["raw title|raw artist"] = ("Fixed Title", "Fixed Artist")
+        title, artist, applied = main._apply_resolved_cache("raw title|raw artist", "raw title", "raw artist")
+        main._resolved_cache.pop("raw title|raw artist", None)
+        ok = applied and title == "Fixed Title" and artist == "Fixed Artist" and main._same_track_field("Same Name", " same   name ")
+        results.append(_result("Track correction cache", ok, "Resolved corrections apply to full metadata tracks"))
+    except Exception as e:
+        results.append(_result("Track correction cache", False, str(e)))
+
+    try:
         import diagnostics_ui
         cards = diagnostics_ui._build_cards({}, load_config(), {"value": "Unavailable", "state": "bad"})
         results.append(_result("Diagnostics cards", len(cards) == 7, f"{len(cards)} cards"))
@@ -107,7 +145,13 @@ def run_self_tests(log_dir, diagnostics_path):
             .replace("{config_json}", json.dumps(settings_ui._settings_payload()))
         )
         script = html[html.index("<script>") + len("<script>"):html.index("</script>")]
-        ok = "What\\\\'s new" not in script and "\\n\\nWhat's new:\\n" in script and "async function init()" in script
+        ok = (
+            "What\\\\'s new" not in script
+            and "\\n\\nWhat's new:\\n" in script
+            and "async function init()" in script
+            and "renderCustomAlbums" in script
+            and "custom_albums" in script
+        )
         results.append(_result("Settings script", ok, "Settings JavaScript guard"))
     except Exception as e:
         results.append(_result("Settings script", False, str(e)))

--- a/settings_ui.py
+++ b/settings_ui.py
@@ -37,6 +37,29 @@ def _save_window_size(width, height):
     save_config(config)
 
 
+def _split_aliases(value):
+    if isinstance(value, list):
+        items = value
+    else:
+        items = str(value or "").replace("\n", ",").split(",")
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _clean_custom_albums(items):
+    if not isinstance(items, list):
+        return []
+    cleaned = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        album = str(item.get("album", "")).strip()
+        art_url = str(item.get("art_url", "")).strip()
+        aliases = _split_aliases(item.get("aliases", []))
+        if album and art_url:
+            cleaned.append({"album": album, "aliases": aliases, "art_url": art_url})
+    return cleaned
+
+
 def _settings_payload():
     cfg = load_config()
     try:
@@ -46,6 +69,7 @@ def _settings_payload():
     keys = [
         "discord_client_id",
         "use_custom_client_id",
+        "custom_albums",
         "start_on_startup",
         "start_minimized",
         "show_paused",
@@ -60,7 +84,9 @@ def _settings_payload():
         "listenbrainz_token",
         "intro_seen",
     ]
-    return {key: cfg.get(key) for key in keys}
+    payload = {key: cfg.get(key) for key in keys}
+    payload["custom_albums"] = _clean_custom_albums(payload.get("custom_albums"))
+    return payload
 
 
 HTML_TEMPLATE = """<!DOCTYPE html>
@@ -258,6 +284,50 @@ HTML_TEMPLATE = """<!DOCTYPE html>
   }
   .lastfm-status.connected { color: #43b581; }
   .lastfm-status.disconnected { color: #f04747; }
+
+  .custom-album-list {
+    display: grid;
+    gap: 10px;
+  }
+  .custom-album-item {
+    background: #262626;
+    border: 1px solid #3d3d3d;
+    border-radius: 8px;
+    padding: 12px;
+  }
+  .custom-album-fields {
+    display: grid;
+    gap: 8px;
+  }
+  .custom-album-fields label {
+    font-size: 11px;
+    color: #888;
+    display: block;
+    margin-bottom: 4px;
+  }
+  .custom-album-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 10px;
+  }
+  .mini-btn {
+    padding: 7px 12px;
+    background: #383838;
+    color: #e4e4e4;
+    border: 1px solid #4a4a4a;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .mini-btn:hover { border-color: #5865f2; background: #404040; }
+  .mini-btn.remove { color: #ff9b9b; }
+  .empty-state {
+    color: #888;
+    font-size: 12px;
+    padding: 4px 0 10px;
+  }
   .auth-btn {
     padding: 7px 14px;
     background: #d51007;
@@ -559,6 +629,13 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 </div>
 
 <div class="card">
+  <div class="card-title">Custom Album Art</div>
+  <div class="row-desc" style="margin-bottom:10px;">Match album names or aliases to a custom cover image URL</div>
+  <div class="custom-album-list" id="customAlbumList"></div>
+  <button class="update-btn" type="button" onclick="addCustomAlbum()">Add Album Art</button>
+</div>
+
+<div class="card">
   <div class="card-title">Settings</div>
 
   <div class="row">
@@ -714,6 +791,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 
 <script>
   const BOOTSTRAP_CONFIG = {config_json};
+  let customAlbums = [];
 
   function showSettingsStatus(text, kind) {
     const status = document.getElementById('updateStatus');
@@ -740,6 +818,75 @@ HTML_TEMPLATE = """<!DOCTYPE html>
       group.classList.remove('visible');
       document.getElementById('idError').style.display = 'none';
     }
+  }
+
+  function escapeHtml(value) {
+    return String(value || '').replace(/[&<>"']/g, (ch) => ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    }[ch]));
+  }
+
+  function splitAliasText(value) {
+    return String(value || '').split(/[\\n,]+/).map((item) => item.trim()).filter(Boolean);
+  }
+
+  function collectCustomAlbums(keepEmpty) {
+    return Array.from(document.querySelectorAll('.custom-album-item')).map((item) => {
+      const album = item.querySelector('[data-field="album"]').value.trim();
+      const aliases = splitAliasText(item.querySelector('[data-field="aliases"]').value);
+      const artUrl = item.querySelector('[data-field="art_url"]').value.trim();
+      return { album, aliases, art_url: artUrl };
+    }).filter((item) => keepEmpty || (item.album && item.art_url));
+  }
+
+  function renderCustomAlbums(items) {
+    customAlbums = Array.isArray(items) ? items.map((item) => ({
+      album: item.album || '',
+      aliases: Array.isArray(item.aliases) ? item.aliases : splitAliasText(item.aliases || ''),
+      art_url: item.art_url || ''
+    })) : [];
+    const list = document.getElementById('customAlbumList');
+    if (!customAlbums.length) {
+      list.innerHTML = '<div class="empty-state">No custom album art configured.</div>';
+      return;
+    }
+    list.innerHTML = customAlbums.map((item, index) => `
+      <div class="custom-album-item">
+        <div class="custom-album-fields">
+          <div>
+            <label>Album</label>
+            <input type="text" data-field="album" value="${escapeHtml(item.album)}" placeholder="Album name">
+          </div>
+          <div>
+            <label>Alternative names</label>
+            <textarea data-field="aliases" placeholder="One alias per line">${escapeHtml(item.aliases.join('\\n'))}</textarea>
+          </div>
+          <div>
+            <label>Cover image URL</label>
+            <input type="text" data-field="art_url" value="${escapeHtml(item.art_url)}" placeholder="https://example.com/cover.jpg">
+          </div>
+        </div>
+        <div class="custom-album-actions">
+          <button class="mini-btn remove" type="button" onclick="removeCustomAlbum(${index})">Remove</button>
+        </div>
+      </div>
+    `).join('');
+  }
+
+  function addCustomAlbum() {
+    customAlbums = collectCustomAlbums(true);
+    customAlbums.push({ album: '', aliases: [], art_url: '' });
+    renderCustomAlbums(customAlbums);
+  }
+
+  function removeCustomAlbum(index) {
+    customAlbums = collectCustomAlbums(true);
+    customAlbums.splice(index, 1);
+    renderCustomAlbums(customAlbums);
   }
 
   function onLastfmToggle() {
@@ -867,6 +1014,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
       privacy_private_session: document.getElementById('privacyPrivateSession').checked,
       privacy_disable_scrobbling: document.getElementById('privacyDisableScrobbling').checked,
       privacy_blocked_keywords: document.getElementById('privacyBlockedKeywords').value.trim(),
+      custom_albums: collectCustomAlbums(false),
       song_link_enabled: document.getElementById('songLinkEnabled').checked,
       notification_enrichment_enabled: document.getElementById('notifEnrichEnabled').checked,
       lastfm_enabled: document.getElementById('lastfmEnabled').checked,
@@ -910,6 +1058,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
     document.getElementById('privacyPrivateSession').checked = !!cfg.privacy_private_session;
     document.getElementById('privacyDisableScrobbling').checked = cfg.privacy_disable_scrobbling !== false;
     document.getElementById('privacyBlockedKeywords').value = cfg.privacy_blocked_keywords || '';
+    renderCustomAlbums(cfg.custom_albums || []);
     document.getElementById('songLinkEnabled').checked = !!cfg.song_link_enabled;
     document.getElementById('notifEnrichEnabled').checked = !!cfg.notification_enrichment_enabled;
     if (cfg.notification_enrichment_enabled) {
@@ -1140,6 +1289,7 @@ class _Api:
             "privacy_private_session": bool(data.get("privacy_private_session")),
             "privacy_disable_scrobbling": bool(data.get("privacy_disable_scrobbling", True)),
             "privacy_blocked_keywords": data.get("privacy_blocked_keywords", "").strip(),
+            "custom_albums": _clean_custom_albums(data.get("custom_albums", [])),
             "song_link_enabled": bool(data.get("song_link_enabled")),
             "notification_enrichment_enabled": bool(data.get("notification_enrichment_enabled")),
             "lastfm_enabled": bool(data.get("lastfm_enabled")),
@@ -1167,11 +1317,12 @@ class SettingsWindow:
         config = load_config()
         width = _bounded_int(config.get("settings_window_width"), 460, 420)
         height = _bounded_int(config.get("settings_window_height"), 800, 560)
+        config_json = json.dumps(_settings_payload()).replace("</", "<\\/")
         html = (
             HTML_TEMPLATE
             .replace("{icon_b64}", _icon_b64())
             .replace("{version}", APP_VERSION)
-            .replace("{config_json}", json.dumps(_settings_payload()))
+            .replace("{config_json}", config_json)
         )
 
         window_holder = [None]

--- a/track_picker.py
+++ b/track_picker.py
@@ -30,9 +30,43 @@ def _load_thumbnail(url, size=50):
         return None
 
 
-def show_choice_picker(title, choices):
-    result = {"index": -1, "remember": False}
+def _track_payload(track):
+    return {
+        "title": track.get("title", ""),
+        "artist": track.get("artist", ""),
+        "album": track.get("album", ""),
+        "art_url": track.get("art_url", ""),
+        "track_link": track.get("track_link", ""),
+        "duration": track.get("duration", 0) or 0,
+    }
+
+
+def _search_page(query, page_size, page, search_fn=None):
+    offset = max(0, int(page)) * max(1, int(page_size))
+    if search_fn:
+        try:
+            return search_fn(query, limit=page_size, offset=offset)
+        except TypeError:
+            if offset:
+                return []
+            return search_fn(query, limit=page_size)
+    from album_art import search_tracks
+    return search_tracks(query, limit=page_size, offset=offset)
+
+
+def _center_window(root, min_width):
+    root.update_idletasks()
+    w = max(root.winfo_reqwidth(), min_width)
+    h = root.winfo_reqheight()
+    x = (root.winfo_screenwidth() - w) // 2
+    y = (root.winfo_screenheight() - h) // 2
+    root.geometry(f"{w}x{h}+{x}+{y}")
+
+
+def show_choice_picker(title, choices, search_query=None, page_size=5, prompt="No artist found. Select the correct track:", remember=True, search_fn=None):
+    result = {"index": -1, "remember": False, "track": None}
     _photo_refs.clear()
+    page_size = max(1, int(page_size or 5))
 
     root = tk.Tk()
     root.title("Amazon Music RPC")
@@ -50,69 +84,139 @@ def show_choice_picker(title, choices):
     ).pack(padx=20, pady=(16, 4), anchor="w")
 
     tk.Label(
-        root, text="No artist found. Select the correct track:",
+        root, text=prompt,
         bg=BG, fg=FG_DIM, font=small_font
     ).pack(padx=20, pady=(0, 10), anchor="w")
 
     selected = tk.IntVar(value=-1)
+    pages = {0: list(choices or [])}
+    current_page = [0]
+    exhausted_pages = set()
+    list_frame = tk.Frame(root, bg=BG)
+    list_frame.pack(fill="x")
+    status_label = tk.Label(root, text="", bg=BG, fg=FG_DIM, font=small_font)
+    status_label.pack(padx=20, pady=(4, 2), anchor="w")
 
-    for i, c in enumerate(choices):
-        row_frame = tk.Frame(root, bg=CARD_BG, highlightbackground=BORDER, highlightthickness=1)
-        row_frame.pack(fill="x", padx=16, pady=2)
-
-        rb = tk.Radiobutton(
-            row_frame, variable=selected, value=i,
-            bg=CARD_BG, selectcolor=BTN_BG,
-            activebackground=CARD_BG, highlightthickness=0, bd=0
-        )
-        rb.pack(side="left", padx=(8, 4), pady=6)
-
-        thumb = _load_thumbnail(c.get("art_url", ""), 48) if c.get("art_url") else None
-        if thumb:
-            _photo_refs.append(thumb)
-            tk.Label(row_frame, image=thumb, bg=CARD_BG, bd=0).pack(side="left", padx=(0, 8), pady=4)
-        else:
-            placeholder = tk.Frame(row_frame, bg="#444", width=48, height=48)
-            placeholder.pack_propagate(False)
-            placeholder.pack(side="left", padx=(0, 8), pady=4)
-
-        info_frame = tk.Frame(row_frame, bg=CARD_BG)
-        info_frame.pack(side="left", fill="x", expand=True, pady=4)
-
-        tk.Label(
-            info_frame, text=c.get("title", ""), bg=CARD_BG, fg="#fff",
-            font=main_font, anchor="w"
-        ).pack(anchor="w")
-        tk.Label(
-            info_frame, text=c.get("artist", ""), bg=CARD_BG, fg=FG,
-            font=small_font, anchor="w"
-        ).pack(anchor="w")
-        album_text = c.get("album", "")
-        if album_text:
+    def render_choices():
+        for child in list_frame.winfo_children():
+            child.destroy()
+        _photo_refs.clear()
+        selected.set(-1)
+        page_choices = pages.get(current_page[0], [])
+        if not page_choices:
             tk.Label(
-                info_frame, text=album_text, bg=CARD_BG, fg=FG_DIM,
+                list_frame, text="No results found on this page.",
+                bg=BG, fg=FG_DIM, font=small_font
+            ).pack(padx=20, pady=12, anchor="w")
+        for i, c in enumerate(page_choices):
+            row_frame = tk.Frame(list_frame, bg=CARD_BG, highlightbackground=BORDER, highlightthickness=1)
+            row_frame.pack(fill="x", padx=16, pady=2)
+
+            rb = tk.Radiobutton(
+                row_frame, variable=selected, value=i,
+                bg=CARD_BG, selectcolor=BTN_BG,
+                activebackground=CARD_BG, highlightthickness=0, bd=0
+            )
+            rb.pack(side="left", padx=(8, 4), pady=6)
+
+            thumb = _load_thumbnail(c.get("art_url", ""), 48) if c.get("art_url") else None
+            if thumb:
+                _photo_refs.append(thumb)
+                tk.Label(row_frame, image=thumb, bg=CARD_BG, bd=0).pack(side="left", padx=(0, 8), pady=4)
+            else:
+                placeholder = tk.Frame(row_frame, bg="#444", width=48, height=48)
+                placeholder.pack_propagate(False)
+                placeholder.pack(side="left", padx=(0, 8), pady=4)
+
+            info_frame = tk.Frame(row_frame, bg=CARD_BG)
+            info_frame.pack(side="left", fill="x", expand=True, pady=4)
+
+            tk.Label(
+                info_frame, text=c.get("title", ""), bg=CARD_BG, fg="#fff",
+                font=main_font, anchor="w"
+            ).pack(anchor="w")
+            tk.Label(
+                info_frame, text=c.get("artist", ""), bg=CARD_BG, fg=FG,
                 font=small_font, anchor="w"
             ).pack(anchor="w")
+            album_text = c.get("album", "")
+            if album_text:
+                tk.Label(
+                    info_frame, text=album_text, bg=CARD_BG, fg=FG_DIM,
+                    font=small_font, anchor="w"
+                ).pack(anchor="w")
+        page_label.configure(text=f"Page {current_page[0] + 1}")
+        prev_btn.configure(state="normal" if current_page[0] > 0 else "disabled")
+        can_next = bool(search_query) and current_page[0] not in exhausted_pages and len(page_choices) >= page_size
+        next_btn.configure(state="normal" if can_next else "disabled")
+        _center_window(root, 500)
+
+    def load_page(page):
+        if page < 0:
+            return
+        if page in pages:
+            current_page[0] = page
+            status_label.configure(text="")
+            render_choices()
+            return
+        if not search_query:
+            return
+        status_label.configure(text="Searching...")
+        root.update_idletasks()
+        tracks = _search_page(search_query, page_size, page, search_fn)
+        if not tracks:
+            exhausted_pages.add(page - 1)
+            status_label.configure(text="No more results.")
+            render_choices()
+            return
+        pages[page] = tracks
+        current_page[0] = page
+        status_label.configure(text="")
+        if len(tracks) < page_size:
+            exhausted_pages.add(page)
+        render_choices()
 
     remember_var = tk.BooleanVar(value=False)
-    tk.Checkbutton(
-        root, text="Always use this for this title", variable=remember_var,
-        bg=BG, fg=FG_DIM, selectcolor=BTN_BG,
-        activebackground=BG, activeforeground=FG,
-        font=small_font, highlightthickness=0, bd=0
-    ).pack(padx=20, pady=(6, 8), anchor="w")
+    if remember:
+        tk.Checkbutton(
+            root, text="Always use this for this title", variable=remember_var,
+            bg=BG, fg=FG_DIM, selectcolor=BTN_BG,
+            activebackground=BG, activeforeground=FG,
+            font=small_font, highlightthickness=0, bd=0
+        ).pack(padx=20, pady=(6, 8), anchor="w")
 
     btn_frame = tk.Frame(root, bg=BG)
     btn_frame.pack(fill="x", padx=16, pady=(0, 14))
 
     def on_select():
-        if selected.get() >= 0:
-            result["index"] = selected.get()
+        selected_index = selected.get()
+        page_choices = pages.get(current_page[0], [])
+        if selected_index >= 0 and selected_index < len(page_choices):
+            chosen = page_choices[selected_index]
+            result["index"] = current_page[0] * page_size + selected_index
             result["remember"] = remember_var.get()
+            result["track"] = _track_payload(chosen)
         root.destroy()
 
     def on_skip():
         root.destroy()
+
+    prev_btn = tk.Button(
+        btn_frame, text="Previous", command=lambda: load_page(current_page[0] - 1),
+        bg=BTN_BG, fg=FG, font=main_font, relief="flat",
+        padx=12, pady=4, cursor="hand2"
+    )
+    prev_btn.pack(side="left")
+
+    page_label = tk.Label(btn_frame, text="Page 1", bg=BG, fg=FG_DIM, font=small_font)
+    page_label.pack(side="left", padx=8)
+
+    next_btn = tk.Button(
+        btn_frame, text="Next", command=lambda: load_page(current_page[0] + 1),
+        bg=BTN_BG, fg=FG, font=main_font, relief="flat",
+        padx=12, pady=4, cursor="hand2"
+    )
+    next_btn.pack(side="left")
 
     tk.Button(
         btn_frame, text="Select", command=on_select,
@@ -126,12 +230,7 @@ def show_choice_picker(title, choices):
         padx=16, pady=4, cursor="hand2"
     ).pack(side="right")
 
-    root.update_idletasks()
-    w = max(root.winfo_reqwidth(), 480)
-    h = root.winfo_reqheight()
-    x = (root.winfo_screenwidth() - w) // 2
-    y = (root.winfo_screenheight() - h) // 2
-    root.geometry(f"{w}x{h}+{x}+{y}")
+    render_choices()
 
     root.protocol("WM_DELETE_WINDOW", on_skip)
     root.mainloop()
@@ -241,26 +340,38 @@ def show_input_picker(artist, search_fn=None):
 
     btn_frame = tk.Frame(root, bg=BG)
     btn_frame.pack(fill="x", padx=16, pady=(0, 14))
+    status_label = tk.Label(root, text="", bg=BG, fg=FG_DIM, font=small_font)
+    status_label.pack(padx=20, pady=(0, 8), anchor="w")
 
     def on_search(event=None):
         query = entry.get().strip()
         if not query:
             return
-        if search_fn:
-            tracks = search_fn(f"{query} {artist}", limit=1)
-        else:
-            from album_art import search_tracks
-            tracks = search_tracks(f"{query} {artist}", limit=1)
+        search_query = f"{query} {artist}"
+        status_label.configure(text="Searching...")
+        root.update_idletasks()
+        tracks = _search_page(search_query, 5, 0, search_fn)
         if not tracks:
+            status_label.configure(text="No results found.")
             return
-        track_info = tracks[0]
-        accepted = _show_confirm(root, track_info, main_font, small_font)
-        if accepted:
+        root.destroy()
+        picked = show_choice_picker(
+            query,
+            tracks,
+            search_query=search_query,
+            page_size=5,
+            prompt="Select the correct track:",
+            remember=False,
+            search_fn=search_fn,
+        )
+        track_info = picked.get("track") or {}
+        if track_info:
             result["title"] = track_info.get("title", query)
             result["artist"] = track_info.get("artist", artist)
             result["album"] = track_info.get("album", "")
             result["art_url"] = track_info.get("art_url", "")
-            root.destroy()
+            result["track_link"] = track_info.get("track_link", "")
+            result["duration"] = track_info.get("duration", 0) or 0
 
     def on_skip():
         root.destroy()
@@ -279,12 +390,7 @@ def show_input_picker(artist, search_fn=None):
         padx=16, pady=4, cursor="hand2"
     ).pack(side="right")
 
-    root.update_idletasks()
-    w = max(root.winfo_reqwidth(), 400)
-    h = root.winfo_reqheight()
-    x = (root.winfo_screenwidth() - w) // 2
-    y = (root.winfo_screenheight() - h) // 2
-    root.geometry(f"{w}x{h}+{x}+{y}")
+    _center_window(root, 400)
 
     root.protocol("WM_DELETE_WINDOW", on_skip)
     root.mainloop()
@@ -404,7 +510,12 @@ def run_from_file(filepath):
     mode = request.get("mode")
 
     if mode == "choice":
-        response = show_choice_picker(request["title"], request["choices"])
+        response = show_choice_picker(
+            request["title"],
+            request["choices"],
+            search_query=request.get("search_query") or request.get("title", ""),
+            page_size=request.get("page_size", 5),
+        )
     elif mode == "input":
         response = show_input_picker(request["artist"])
     elif mode == "wrongsong":


### PR DESCRIPTION
## Summary

- Adds paged result navigation to both song picker flows so users can move beyond the first five search results.
- Carries selected track metadata back into the RPC loop so corrected title, artist, album art, link, and duration are applied.
- Adds custom album art settings with album aliases and runtime matching.
- Opens the wrong-song picker when the track title and artist normalize to the same value.
- Bumps the app and installer version to 2.2.3.

## Root Cause

Picker selections were stored for missing metadata cases, but manual corrections could be skipped when the current track already had both title and artist. The RPC loop now applies correction cache entries before the rest of the track handling.

## Validation

- `py -3.14 -m compileall -q .`
- `self_tests.run_self_tests('.', 'diagnostics.json')`
- rendered Settings JavaScript checked with `node --check`

No installer build was run for this PR.