### PR TITLE
Fix one-letter album RPC payloads

### DIFF
--- a/amazon_devtools.py
+++ b/amazon_devtools.py
@@ -482,6 +482,34 @@ Add-Type -TypeDefinition $code
     return {"ok": True, "pid": _clean(completed.stdout)}
 
 
+def amazon_music_is_running():
+    script = rf"""
+$package = '{AMAZON_PACKAGE_NAME}'
+$targets = @(Get-Process | Where-Object {{
+    $path = ""
+    try {{ $path = $_.Path }} catch {{ }}
+    $_.MainWindowHandle -ne 0 -and
+    (($path -and $path -like "*$package*") -or
+    ($_.ProcessName -eq "AmazonMusic") -or
+    ($_.ProcessName -eq "Amazon Music")) -and
+    ($_.ProcessName -ne "Amazon Music Helper")
+}})
+if ($targets.Count -gt 0) {{ "true" }} else {{ "false" }}
+"""
+    try:
+        completed = subprocess.run(
+            ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=5,
+            creationflags=0x08000000 if os.name == "nt" else 0,
+        )
+    except Exception:
+        return False
+    return completed.returncode == 0 and _clean(completed.stdout).lower() == "true"
+
+
 def stop_amazon_music():
     script = rf"""
 $package = '{AMAZON_PACKAGE_NAME}'

--- a/discord_rpc.py
+++ b/discord_rpc.py
@@ -7,6 +7,22 @@ from pypresence import Presence
 from pypresence.types import ActivityType
 
 
+def _discord_asset_text(album_name, title):
+    album = str(album_name or "").strip()
+    if len(album) >= 2:
+        return album[:128]
+    if album:
+        return f"Album: {album}"[:128]
+
+    track = str(title or "").strip()
+    if len(track) >= 2:
+        return track[:128]
+    if track:
+        return f"Track: {track}"[:128]
+
+    return "Unknown Album"
+
+
 class DiscordRPC:
     def __init__(self, client_id):
         self.client_id = client_id
@@ -55,7 +71,7 @@ class DiscordRPC:
             "details": title[:128] if title else "Unknown Title",
             "state": f"by {artist}" if artist else "Unknown Artist",
             "assets": {
-                "large_text": album_name if album_name else f"{title}",
+                "large_text": _discord_asset_text(album_name, title),
             },
             "instance": True,
         }

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ import pystray
 from media_reader import get_track_sync
 from notification_reader import get_notification_track_sync, is_new_notification
 from album_art import get_album_art, search_tracks, find_custom_album_art
-from amazon_devtools import get_devtools_track_sync, apply_devtools_to_track, launch_amazon_music_devtools, restart_amazon_music_devtools
+from amazon_devtools import get_devtools_track_sync, apply_devtools_to_track, launch_amazon_music_devtools, restart_amazon_music_devtools, amazon_music_is_running
 from discord_rpc import DiscordRPC
 from config import load_config, save_config, get_exe_path, DEFAULT_CLIENT_ID, CONFIG_PATH, APP_VERSION
 from updater import check_for_update, prompt_for_update
@@ -490,7 +490,6 @@ def rpc_loop():
     amazon_devtools_enabled = config.get("amazon_devtools_enabled", False)
     amazon_devtools_auto_launch = config.get("amazon_devtools_auto_launch", True)
     privacy_disable_scrobbling = config.get("privacy_disable_scrobbling", True)
-    devtools_auto_launch_attempted = False
     devtools_restart_attempted = False
     devtools_unavailable_since = None
     last_amazon_metadata_key = None
@@ -607,7 +606,6 @@ def rpc_loop():
                     _current_amazon_devtools = {"enabled": True, **devtools}
                     if devtools.get("status") == "found":
                         devtools_unavailable_since = None
-                        devtools_auto_launch_attempted = False
                         devtools_restart_attempted = False
                         devtools_found = True
                         _current_notif_data = None
@@ -627,43 +625,42 @@ def rpc_loop():
                             print(f"[Amazon] Metadata: '{track.get('title', '')}' by '{track.get('artist', '')}'")
                     elif devtools.get("status") == "unavailable" and amazon_devtools_auto_launch:
                         now = time.time()
-                        if devtools_unavailable_since is None:
-                            devtools_unavailable_since = now
-                        if not devtools_auto_launch_attempted:
-                            devtools_auto_launch_attempted = True
-                            launch_result = launch_amazon_music_devtools()
-                            if launch_result.get("ok"):
-                                devtools_unavailable_since = time.time()
+                        if not amazon_music_is_running():
+                            devtools_unavailable_since = None
+                            devtools_restart_attempted = False
+                            _current_amazon_devtools = {
+                                "enabled": True,
+                                "status": "waiting",
+                                "detail": "Amazon Music is closed; waiting for you to open it",
+                                "source": "amazon_devtools",
+                            }
+                        else:
+                            if devtools_unavailable_since is None:
+                                devtools_unavailable_since = now
+                                devtools_restart_attempted = False
+                            if not devtools_restart_attempted and now - devtools_unavailable_since >= DEVTOOLS_REPAIR_GRACE_SECONDS:
+                                devtools_restart_attempted = True
+                                restart_result = restart_amazon_music_devtools()
+                                if restart_result.get("ok"):
+                                    _current_amazon_devtools = {
+                                        "enabled": True,
+                                        "status": "restarting",
+                                        "detail": "Restarted Amazon Music for metadata",
+                                        "source": "amazon_devtools",
+                                    }
+                                    print("[Amazon] Restarted Amazon Music for metadata.")
+                                else:
+                                    _current_amazon_devtools = {
+                                        "enabled": True,
+                                        "status": "error",
+                                        "detail": restart_result.get("error") or "Could not restart Amazon Music for metadata",
+                                        "source": "amazon_devtools",
+                                    }
+                            elif not devtools_restart_attempted:
                                 _current_amazon_devtools = {
                                     "enabled": True,
-                                    "status": "launching",
-                                    "detail": "Amazon Music launched for metadata",
-                                    "source": "amazon_devtools",
-                                }
-                                print("[Amazon] Launched Amazon Music for metadata.")
-                            else:
-                                _current_amazon_devtools = {
-                                    "enabled": True,
-                                    "status": "error",
-                                    "detail": launch_result.get("error") or "Could not launch Amazon Music for metadata",
-                                    "source": "amazon_devtools",
-                                }
-                        elif not devtools_restart_attempted and now - devtools_unavailable_since >= DEVTOOLS_REPAIR_GRACE_SECONDS:
-                            devtools_restart_attempted = True
-                            restart_result = restart_amazon_music_devtools()
-                            if restart_result.get("ok"):
-                                _current_amazon_devtools = {
-                                    "enabled": True,
-                                    "status": "restarting",
-                                    "detail": "Restarted Amazon Music for metadata",
-                                    "source": "amazon_devtools",
-                                }
-                                print("[Amazon] Restarted Amazon Music for metadata.")
-                            else:
-                                _current_amazon_devtools = {
-                                    "enabled": True,
-                                    "status": "error",
-                                    "detail": restart_result.get("error") or "Could not restart Amazon Music for metadata",
+                                    "status": "waiting",
+                                    "detail": "Amazon Music is open without enhanced metadata; restart repair pending",
                                     "source": "amazon_devtools",
                                 }
                 except Exception as e:

--- a/self_tests.py
+++ b/self_tests.py
@@ -76,6 +76,18 @@ def run_self_tests(log_dir, diagnostics_path):
         results.append(_result("Metadata cleanup", False, str(e)))
 
     try:
+        from discord_rpc import _discord_asset_text
+        ok = (
+            _discord_asset_text("Z", "Off the Record") == "Album: Z"
+            and _discord_asset_text("", "A") == "Track: A"
+            and _discord_asset_text("Wolf", "IFHY") == "Wolf"
+            and len(_discord_asset_text("Z", "Off the Record")) >= 2
+        )
+        results.append(_result("Discord asset text", ok, "One-letter albums are expanded for Discord validation"))
+    except Exception as e:
+        results.append(_result("Discord asset text", False, str(e)))
+
+    try:
         import inspect
         from album_art import search_tracks
         params = inspect.signature(search_tracks).parameters
@@ -164,10 +176,10 @@ def run_self_tests(log_dir, diagnostics_path):
         results.append(_result("Amazon DevTools diagnostics state", False, str(e)))
 
     try:
-        from amazon_devtools import amazon_devtools_launcher_state, _shortcut_launcher_command
+        from amazon_devtools import amazon_devtools_launcher_state, _shortcut_launcher_command, amazon_music_is_running
         state = amazon_devtools_launcher_state()
         target, arguments, working_dir, icon_path = _shortcut_launcher_command()
-        ok = state.get("path", "").endswith("Amazon Music Metadata.lnk") and target and "--launch-amazon-devtools" in arguments and working_dir and icon_path
+        ok = state.get("path", "").endswith("Amazon Music Metadata.lnk") and target and "--launch-amazon-devtools" in arguments and working_dir and icon_path and isinstance(amazon_music_is_running(), bool)
         results.append(_result("Amazon DevTools launcher", ok, "Launcher command and cleanup path are available"))
     except Exception as e:
         results.append(_result("Amazon DevTools launcher", False, str(e)))
@@ -223,6 +235,7 @@ def run_self_tests(log_dir, diagnostics_path):
             and "song_link_provider" in script
             and "songLinkProvider" in script
             and "Show listen button" in html
+            and "Auto-restart Amazon Music" in html
             and card_order == sorted(card_order)
             and "metadataWarning" in html
             and "closeMetadataWarning" in script

--- a/settings_ui.py
+++ b/settings_ui.py
@@ -683,11 +683,11 @@ HTML_TEMPLATE = """<!DOCTYPE html>
   <div class="separator"></div>
   <div class="row">
     <div class="row-labels">
-      <span class="row-label">Auto-launch Amazon Music</span>
-      <div class="row-desc">Start or restart Amazon Music for metadata when RPC starts</div>
+      <span class="row-label">Auto-restart Amazon Music</span>
+      <div class="row-desc">Restart Amazon Music for metadata only when it is already open</div>
     </div>
     <label class="toggle">
-      <input type="checkbox" id="amazonDevtoolsAutoLaunch" aria-label="Auto-launch Amazon Music metadata">
+      <input type="checkbox" id="amazonDevtoolsAutoLaunch" aria-label="Auto-restart Amazon Music metadata">
       <div class="toggle-track"></div>
       <div class="toggle-knob"></div>
     </label>


### PR DESCRIPTION
## Summary
- Fix Discord RPC payloads for one-letter album names by expanding asset hover text like `Z` to `Album: Z`
- Keep normal album names unchanged and add regression coverage
- Stop auto-starting Amazon Music when it is closed; auto-repair now only restarts Amazon Music when a visible Amazon Music window is already open without enhanced metadata
- Update Settings copy from auto-launch to auto-restart

Fixes #6

## Tests
- `py -3.14 -m compileall -q .`
- `py -3.14 -c "import self_tests; results=self_tests.run_self_tests('.', 'diagnostics.json'); print(sum(1 for r in results if r['status']=='pass'), '/', len(results)); print([r for r in results if r['status']!='pass'])"` -> `19 / 19`