### PR TITLE
Merge macOS beta prototype

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -1,0 +1,36 @@
+name: macOS Tests
+
+on:
+  push:
+    branches:
+      - master
+      - "beta/**"
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  macos-tests:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12.10"
+          cache: pip
+          cache-dependency-path: |
+            MacOS/requirements.txt
+            MacOS/requirements-build.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r MacOS/requirements.txt pytest
+      - name: Compile
+        run: python -m compileall -q MacOS Shared
+      - name: Test
+        run: python -m pytest

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Compile
         run: python -m py_compile Windows/main.py Windows/desktop_runtime.py Windows/app_models.py Windows/runtime_state.py Windows/task_supervisor.py Windows/structured_logging.py Windows/window_controller.py Windows/rpc_controller.py Windows/command_controller.py Windows/amazon_devtools.py Windows/amazon_domains.py Windows/amazon_status_overlay.py Windows/amazify_compat.py Windows/media_reader.py Windows/discord_rpc.py Windows/config.py Windows/credential_store.py Windows/network_audit.py Windows/updater.py Windows/status_summary.py Windows/tray_state.py Windows/qt_tray_ui.py Windows/rpc_state.py Windows/metadata_pipeline.py Windows/launcher_diagnostics.py Windows/safe_image.py Windows/settings_config.py Windows/security_trust.py Windows/self_tests.py Windows/release_artifact.py Windows/release_smoke.py
       - name: Pytest with coverage threshold
-        run: python -m pytest Windows/tests --cov=Windows --cov-report=term-missing --cov-fail-under=45
+        run: python -m pytest --cov=Windows --cov-report=term-missing --cov-fail-under=45
       - name: Built-in self-tests
         run: python Windows/run_self_tests.py
       - name: Ruff safety checks

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Windows/build/
 Windows/dist/
 Windows/installer_output/
 TestBuild/
+.DS_Store
 
 __pycache__/
 *.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,9 @@ https://github.com/eripum9/Amazon-Music-Discord-RPC/releases/latest
 For bugs, include:
 
 - Amazon Music RPC version
-- Windows version
-- Install type: installer or source
-- Amazon Music source: Microsoft Store or website installer
+- Platform and OS version
+- Install type: Windows installer, macOS beta DMG, or source
+- Amazon Music app version and source: Microsoft Store/website on Windows or the official macOS app
 - Whether enhanced metadata is enabled
 - Whether fallback metadata or notification enrichment is enabled
 - Exact steps to reproduce
@@ -28,7 +28,8 @@ Do not post Last.fm session keys, ListenBrainz tokens, Discord tokens, config fi
 - `master` is the Windows release branch.
 - `fix/*` branches are for focused issue fixes.
 - `beta/*` branches are for experimental work that should not affect stable Windows releases.
-- Android support is discontinued. Linux and macOS are out of scope unless Amazon releases official desktop apps for those platforms.
+- `beta/MacOS` contains the experimental prototype for Amazon's official macOS desktop app.
+- Android support is discontinued and Linux remains out of scope.
 
 ## Windows Development
 
@@ -64,6 +65,40 @@ Build:
 Windows\build.bat
 ```
 
+## macOS Beta Development
+
+The macOS prototype is developed on `beta/MacOS`; do not describe it as a stable or notarized release. Install and run it from the repository root:
+
+```bash
+git checkout beta/MacOS
+python3.12 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r MacOS/requirements.txt
+python -m pip install -r MacOS/requirements-build.txt
+python -m MacOS.main
+```
+
+Run checks:
+
+```bash
+python -m pytest MacOS/tests Shared/tests
+python -m compileall -q MacOS Shared
+git diff --check
+```
+
+Build the menu-bar app and drag-install DMG:
+
+```bash
+MacOS/scripts/build_app.sh
+MacOS/scripts/create_dmg.sh
+```
+
+The outputs are under `MacOS/dist/`. Mount `Amazon-Music-RPC.dmg`, drag `Amazon Music RPC.app` onto the Applications shortcut in the DMG, eject it, and test the copy in `/Applications`. A build without `MACOS_CODESIGN_IDENTITY` is only ad-hoc signed for local development and is not notarized.
+
+The DevTools integration is primary. If the official Amazon Music app is already open normally, enabling it requires an explicit one-time restart; never add a silent process restart. The Now Playing reader is the read-only fallback. Changes to either path must preserve the validation and permission boundaries in [docs/macos-beta.md](docs/macos-beta.md), [docs/macos-integration-research.md](docs/macos-integration-research.md), and [MacOS/PERMISSIONS.md](MacOS/PERMISSIONS.md).
+
+Discord was not installed during the first prototype build. Automated RPC mocks are useful regression coverage, but a pull request must identify live Discord, Last.fm, ListenBrainz, menu-bar, and clean-machine checks that were not actually performed.
+
 ## Pull Requests
 
 Keep pull requests focused. A good pull request includes:
@@ -79,3 +114,5 @@ For Windows releases, follow [docs/release-checklist.md](docs/release-checklist.
 For supported platform scope, follow [docs/platform-roadmap.md](docs/platform-roadmap.md).
 
 Architecture changes must preserve the controller boundaries in [docs/architecture.md](docs/architecture.md), and security-sensitive changes must update [docs/threat-model.md](docs/threat-model.md) or [docs/network-endpoints.md](docs/network-endpoints.md) when their trust boundaries change.
+
+Platform-neutral playback behavior belongs in `Shared/`. Privacy rules, track normalization/corrections, custom-art matching, process-name matching, and scrobble eligibility must not silently diverge between Windows and macOS. A fundamental behavior change must update the shared implementation or both platform paths, with tests for both builds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,9 @@ Do not post Last.fm session keys, ListenBrainz tokens, Discord tokens, config fi
 
 ## Branches
 
-- `master` is the Windows release branch.
+- `master` contains the stable Windows release and the active macOS beta.
 - `fix/*` branches are for focused issue fixes.
-- `beta/*` branches are for experimental work that should not affect stable Windows releases.
-- `beta/MacOS` contains the experimental prototype for Amazon's official macOS desktop app.
+- `beta/*` branches are for experimental work that is not ready to merge into `master`.
 - Android support is discontinued and Linux remains out of scope.
 
 ## Windows Development
@@ -67,10 +66,10 @@ Windows\build.bat
 
 ## macOS Beta Development
 
-The macOS prototype is developed on `beta/MacOS`; do not describe it as a stable or notarized release. Install and run it from the repository root:
+The macOS implementation is maintained on `master` as an active beta; do not describe it as a published stable or notarized release. Install and run it from the repository root:
 
 ```bash
-git checkout beta/MacOS
+git checkout master
 python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install -r MacOS/requirements.txt
@@ -97,7 +96,7 @@ The outputs are under `MacOS/dist/`. Mount `Amazon-Music-RPC.dmg`, drag `Amazon 
 
 The DevTools integration is primary. If the official Amazon Music app is already open normally, enabling it requires an explicit one-time restart; never add a silent process restart. The Now Playing reader is the read-only fallback. Changes to either path must preserve the validation and permission boundaries in [docs/macos-beta.md](docs/macos-beta.md), [docs/macos-integration-research.md](docs/macos-integration-research.md), and [MacOS/PERMISSIONS.md](MacOS/PERMISSIONS.md).
 
-Discord was not installed during the first prototype build. Automated RPC mocks are useful regression coverage, but a pull request must identify live Discord, Last.fm, ListenBrainz, menu-bar, and clean-machine checks that were not actually performed.
+Discord was not installed during the first macOS development build. Automated RPC mocks are useful regression coverage, but a pull request must identify live Discord, Last.fm, ListenBrainz, menu-bar, and clean-machine checks that were not actually performed.
 
 ## Pull Requests
 

--- a/MacOS/.gitignore
+++ b/MacOS/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/dist/

--- a/MacOS/AmazonMusicRPC.spec
+++ b/MacOS/AmazonMusicRPC.spec
@@ -1,0 +1,110 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import os
+import plistlib
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+
+MACOS_DIR = Path(SPECPATH).resolve()
+PROJECT_DIR = MACOS_DIR.parent
+APP_NAME = "Amazon Music RPC"
+APP_VERSION = os.environ.get("APP_VERSION", "0.1.0")
+APP_BUILD = os.environ.get("APP_BUILD", "1")
+CODESIGN_IDENTITY = os.environ.get("MACOS_CODESIGN_IDENTITY") or None
+ICON_PATH = MACOS_DIR / "build" / "assets" / "AmazonMusicRPC.icns"
+ENTITLEMENTS_PATH = MACOS_DIR / "entitlements.plist"
+SHARED_HIDDEN_IMPORTS = collect_submodules("Shared")
+SHARED_DATA = collect_data_files("Shared")
+
+with (MACOS_DIR / "Info.plist").open("rb") as plist_file:
+    info_plist = plistlib.load(plist_file)
+
+info_plist.update(
+    {
+        "CFBundleShortVersionString": APP_VERSION,
+        "CFBundleVersion": APP_BUILD,
+        "LSMinimumSystemVersion": os.environ.get("MACOSX_DEPLOYMENT_TARGET", "12.0"),
+    }
+)
+
+analysis = Analysis(
+    [str(MACOS_DIR / "main.py")],
+    pathex=[str(PROJECT_DIR), str(MACOS_DIR), str(PROJECT_DIR / "Windows")],
+    binaries=[],
+    datas=[
+        (str(PROJECT_DIR / "Windows" / "icon.png"), "."),
+        (str(MACOS_DIR / "amazon_music_now_playing.js"), "MacOS"),
+        *SHARED_DATA,
+    ],
+    hiddenimports=[
+        "PySide6.QtCore",
+        "PySide6.QtGui",
+        "PySide6.QtNetwork",
+        "PySide6.QtWidgets",
+        "Windows.album_art",
+        "Windows.discord_rpc",
+        "Windows.lastfm",
+        "Windows.listenbrainz_scrobbler",
+        "Windows.network_audit",
+        "Windows.task_supervisor",
+        "liblistenbrainz",
+        "pylast",
+        "pypresence",
+        "pypresence.types",
+        "requests",
+        *SHARED_HIDDEN_IMPORTS,
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        "clr",
+        "msvcrt",
+        "pythonnet",
+        "winreg",
+        "winsdk",
+    ],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(analysis.pure)
+
+exe = EXE(
+    pyz,
+    analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name=APP_NAME,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=CODESIGN_IDENTITY,
+    entitlements_file=str(ENTITLEMENTS_PATH),
+)
+
+collection = COLLECT(
+    exe,
+    analysis.binaries,
+    analysis.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name=APP_NAME,
+)
+
+app = BUNDLE(
+    collection,
+    name=f"{APP_NAME}.app",
+    icon=str(ICON_PATH),
+    bundle_identifier="io.github.eripum9.amazon-music-rpc",
+    version=APP_VERSION,
+    info_plist=info_plist,
+)

--- a/MacOS/Info.plist
+++ b/MacOS/Info.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleDisplayName</key>
+	<string>Amazon Music RPC</string>
+	<key>CFBundleExecutable</key>
+	<string>Amazon Music RPC</string>
+	<key>CFBundleIconFile</key>
+	<string>AmazonMusicRPC.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.github.eripum9.amazon-music-rpc</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Amazon Music RPC</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.music</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>12.0</string>
+	<key>LSMultipleInstancesProhibited</key>
+	<true/>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2026 eripum9. MIT licensed.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+</dict>
+</plist>

--- a/MacOS/PERMISSIONS.md
+++ b/MacOS/PERMISSIONS.md
@@ -1,0 +1,149 @@
+# macOS Permissions, Signing, and Distribution
+
+This document describes the direct-download prototype on macOS 15.7.7. The
+prototype is not an App Store build and is deliberately **not App Sandbox
+enabled**. Its stable bundle identifier is
+`io.github.eripum9.amazon-music-rpc`.
+
+## Permission summary
+
+The normal Discord presence and DevTools metadata path should not show a macOS
+privacy (TCC) prompt. The application does not need Accessibility, Automation,
+Screen Recording, Input Monitoring, Full Disk Access, Media & Apple Music,
+Microphone, Camera, Contacts, or Location access.
+
+| Capability | macOS approval | Notes |
+| --- | --- | --- |
+| Amazon Music metadata over DevTools | None | The app connects only to a random high port on `127.0.0.1`. It verifies that the listener belongs to the signed `com.amazon.music` app before using it. |
+| Start/restart Amazon Music in DevTools mode | None expected | The explicit restart action signals only verified Amazon Music processes owned by the current user, then launches the exact signed executable with loopback-only flags. It does not use Apple Events, System Events, Accessibility, or debugger attachment. |
+| Disable DevTools listener and reopen normally | None expected | This separate, confirmed action interrupts playback, signals only reverified Amazon Music processes, and relaunches the exact signed executable without debugging flags. Merely turning off the RPC checkbox does not alter an already-running Amazon process. |
+| Now Playing fallback | None expected | `/usr/bin/osascript` runs JavaScript that reads the local Now Playing object. It does not send Apple Events to Amazon Music, so Automation permission is not requested. This private-framework compatibility path may stop working on a future macOS release. |
+| Discord Rich Presence | None | Discord IPC uses a Unix-domain socket in the current user's runtime directories. It does not require inbound network or Local Network access. |
+| Last.fm, ListenBrainz, artwork, and updates | Internet connection only | A non-sandboxed direct-download app needs no network entitlement for outbound HTTPS. The macOS application firewall should not ask because Amazon Music RPC does not accept inbound connections. |
+| Last.fm and ListenBrainz secrets | Keychain access may be shown | Secrets are stored as generic passwords in the user's login Keychain. macOS can ask the user to unlock the Keychain or allow access. Denying this prevents persistent scrobbler credentials, but does not grant the app broader data access. |
+| Start at login | User-controlled background item | Enabling this option installs a per-user LaunchAgent in `~/Library/LaunchAgents`. macOS may show a “Background Items Added” notification, and the user can disable it under **System Settings > General > Login Items**. This is not Accessibility or Full Disk Access. |
+| Settings import/export and diagnostics export | User-selected file only | Native open/save dialogs establish the selected location. The app does not scan Desktop, Documents, Downloads, other app containers, or the full disk. |
+| Notifications | Optional user approval if enabled | A future Notification Center banner may trigger the standard Notifications prompt. Denial should affect banners only, not presence or scrobbling. Tray/menu-bar state itself needs no permission. |
+
+Loopback traffic is not traffic to a broadcast-capable Wi-Fi or Ethernet local
+network. The prototype therefore does not declare `NSLocalNetworkUsageDescription`
+and should not appear in **Privacy & Security > Local Network**. It also never
+binds the RPC application itself to a listening TCP port; the verified Amazon
+Music process owns the opt-in DevTools listener.
+
+If a macOS release unexpectedly asks for any permission not listed above, deny
+it first and file a diagnostic report. Core metadata and Discord operation must
+not depend on broad privacy access.
+
+## Entitlements
+
+[`entitlements.plist`](entitlements.plist) is intentionally empty. The app is
+distributed outside the Mac App Store, so App Sandbox is optional. Enabling it
+for this prototype would require a separate design and test pass for process
+inspection, child-process launch, Keychain access, login items, Discord IPC,
+and the Now Playing fallback.
+
+The build does **not** request any of these weakened hardened-runtime
+entitlements:
+
+- `com.apple.security.cs.allow-jit`
+- `com.apple.security.cs.allow-unsigned-executable-memory`
+- `com.apple.security.cs.disable-library-validation`
+- `com.apple.security.cs.allow-dyld-environment-variables`
+- `com.apple.security.cs.debugger`
+- `com.apple.security.get-task-allow`
+
+Amazon Music itself carries several Chromium/JIT entitlements, but Amazon Music
+RPC does not embed Chromium, inject code, attach a debugger, or load code into
+Amazon Music. Copying Amazon's entitlements would unnecessarily weaken the RPC
+application and can make notarization fail.
+
+The app also does not declare the Apple Events entitlement or an
+`NSAppleEventsUsageDescription`, because no runtime path sends Apple Events to
+another application. Add those only if a future feature actually automates an
+application and is designed to handle explicit user consent.
+
+## Prototype signing behavior
+
+`scripts/build_app.sh` always asks PyInstaller to sign the complete bundle:
+
+- With no `MACOS_CODESIGN_IDENTITY`, PyInstaller applies an ad-hoc signature.
+  This is suitable for local development but not public distribution.
+- With `MACOS_CODESIGN_IDENTITY` set to a valid **Developer ID Application**
+  identity, PyInstaller signs nested code and the app with hardened runtime and
+  a secure timestamp. The script fails if strict signature verification fails.
+
+The resulting architecture is inherited from the build Python and all compiled
+wheels. The first verified build host is Intel (`x86_64`). Build separately with
+a native arm64 Python and arm64 wheels for Apple silicon, or introduce a tested
+universal2 release pipeline; changing `target_arch` does not manufacture a
+missing architecture in third-party binaries.
+
+The runtime pins PySide6 Essentials 6.9.3. Direct Mach-O inspection of the
+`x86_64` and `arm64` slices in `QtCore.abi3.so`, `Shiboken.abi3.so`, and
+`QtCore.framework` found a deployment minimum of macOS 12.0 in all six slices.
+The corresponding 6.10.3 binding modules require macOS 15.0 despite their wheel
+metadata, so 6.9.3 is the newest tested Qt-for-Python line compatible with the
+declared macOS 12.0 minimum.
+
+`LSUIElement` is enabled because the prototype is a menu-bar utility. It does
+not keep a Dock or Command-Tab icon running in the background; Settings and
+Diagnostics remain available from the menu-bar item. The original 1024px
+Windows artwork is still used for the `.app`, Finder, DMG, and menu-bar icon.
+
+Ad-hoc builds are not notarizable and Gatekeeper can block them after download.
+Do not label the prototype DMG as a generally distributable release until a
+Developer ID build has passed notarization and clean-machine tests.
+
+## Developer ID and notarization workflow
+
+The scripts never store an Apple ID password or App Store Connect key in the
+repository. A release operator should provision credentials in the login
+Keychain and then run:
+
+```bash
+export MACOS_CODESIGN_IDENTITY='Developer ID Application: Your Name (TEAMID)'
+MacOS/scripts/build_app.sh
+
+xcrun notarytool store-credentials amazon-music-rpc-notary
+export MACOS_NOTARYTOOL_PROFILE='amazon-music-rpc-notary'
+MacOS/scripts/create_dmg.sh
+```
+
+When both variables are present, `create_dmg.sh` signs the DMG, submits it with
+`notarytool --wait`, staples the accepted ticket, and validates the ticket. The
+DMG build itself is noninteractive: `dmgbuild` writes the Finder icon layout and
+the `/Applications` symlink without automating Finder. Every successful build
+atomically produces these two exact release assets; upload both to the same
+GitHub release:
+
+- `Amazon-Music-RPC.dmg`
+- `Amazon-Music-RPC.dmg.sha256`
+
+The checksum is generated only after signing and optional ticket stapling, so
+it matches the final DMG bytes consumed by the automatic updater.
+
+Before publishing a release, also test these manually on a clean macOS account
+or virtual machine:
+
+1. `codesign --verify --deep --strict --verbose=2 "Amazon Music RPC.app"`
+2. `spctl --assess --type execute --verbose=2 "Amazon Music RPC.app"`
+3. `xcrun stapler validate "Amazon-Music-RPC.dmg"`
+4. Mount the DMG, drag the app into Applications, eject it, and launch the
+   installed copy.
+5. Exercise Keychain denial/approval, start-at-login enable/disable, Amazon
+   Music restart consent, Discord absence/reconnection, and both scrobblers.
+
+Do not add `com.apple.security.get-task-allow` to a release. Apple explicitly
+rejects notarization submissions that carry it.
+
+## References
+
+- [Apple: Notarizing macOS software before distribution](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)
+- [Apple: Customizing the notarization workflow](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow)
+- [Apple: Preparing your app for distribution](https://developer.apple.com/documentation/xcode/preparing-your-app-for-distribution)
+- [Apple: App Sandbox](https://developer.apple.com/documentation/security/app-sandbox)
+- [Apple: Apple Events entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.automation.apple-events)
+- [Apple: `NSAppleEventsUsageDescription`](https://developer.apple.com/documentation/bundleresources/information-property-list/nsappleeventsusagedescription)
+- [Apple: Understanding Local Network Privacy](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)
+- [Apple: Privacy & Security settings on Mac](https://support.apple.com/guide/mac-help/change-privacy-security-settings-on-mac-mchl211c911f/mac)

--- a/MacOS/__init__.py
+++ b/MacOS/__init__.py
@@ -1,1 +1,3 @@
+# MIT License - Copyright (c) 2026 eripum9
+
 """macOS integration package for Amazon Music RPC."""

--- a/MacOS/__init__.py
+++ b/MacOS/__init__.py
@@ -1,0 +1,1 @@
+"""macOS integration package for Amazon Music RPC."""

--- a/MacOS/amazon_devtools.py
+++ b/MacOS/amazon_devtools.py
@@ -1,0 +1,1247 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+"""Opt-in Chromium DevTools metadata transport for Amazon Music on macOS.
+
+The DevTools endpoint can inspect an authenticated renderer, so this module
+deliberately exposes only a small, read-only surface.  It never requests
+browser storage, network headers, cookies, or command-line details.
+"""
+
+from __future__ import annotations
+
+import base64
+import ctypes
+import hashlib
+import http.client
+import json
+import math
+import os
+import plistlib
+import random
+import re
+import signal
+import socket
+import struct
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import cast
+from urllib.parse import quote, urlparse
+
+
+AMAZON_MUSIC_APP = Path("/Applications/Amazon Music.app")
+AMAZON_MUSIC_BUNDLE_ID = "com.amazon.music"
+AMAZON_MUSIC_TEAM_ID = "94KV3E626L"
+AMAZON_MUSIC_EXECUTABLE = "Amazon Music"
+DEVTOOLS_PORT_MIN = 49152
+DEVTOOLS_PORT_MAX = 60999
+DISCOVERY_RETRY_SECONDS = 3.0
+MAX_HTTP_RESPONSE_BYTES = 1024 * 1024
+MAX_WEBSOCKET_MESSAGE_BYTES = 1024 * 1024
+MAX_HANDSHAKE_BYTES = 32 * 1024
+
+AMAZON_REGION_SUFFIXES = (
+    "com",
+    "de",
+    "co.uk",
+    "fr",
+    "it",
+    "es",
+    "co.jp",
+    "ca",
+    "com.au",
+    "com.br",
+    "com.mx",
+)
+AMAZON_MUSIC_HOSTS = frozenset(f"music.amazon.{suffix}" for suffix in AMAZON_REGION_SUFFIXES)
+AMAZON_EMBEDDED_WEBAPP_HOSTS = frozenset(
+    f"www.amazon.{suffix}" for suffix in AMAZON_REGION_SUFFIXES
+)
+AMAZON_IMAGE_HOSTS = frozenset(
+    {
+        "m.media-amazon.com",
+        "images-na.ssl-images-amazon.com",
+        "images-eu.ssl-images-amazon.com",
+        "images-fe.ssl-images-amazon.com",
+    }
+)
+
+_EXPLICIT_RE = re.compile(r"\s*\[Explicit\]\s*$", re.IGNORECASE)
+_TIME_RE = re.compile(r"^-?\d{1,3}:\d{2}(?::\d{2})?$")
+_ASIN_RE = re.compile(r"^[A-Z0-9]{10}$", re.IGNORECASE)
+_TARGET_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,256}$")
+_DEVTOOLS_PAGE_PATH_RE = re.compile(r"^/devtools/page/([A-Za-z0-9._:-]{1,256})$")
+
+_DEVTOOLS_PORT: int | None = None
+_LAST_LAUNCH: dict[str, object] = {}
+_CACHE: dict[str, object] = {"key": None, "expires": 0.0, "value": None}
+_INSTALLATION_CACHE: dict[str, object] = {"fingerprint": None, "expires": 0.0, "value": None}
+_DISCOVERY_RETRY_AFTER = 0.0
+
+
+def _clean(value: object, limit: int = 2048) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()[:limit]
+
+
+def _clean_label(value: object) -> str:
+    return _EXPLICIT_RE.sub("", _clean(value, 512)).strip()
+
+
+def _normalise_region(value: object = None) -> str:
+    region = _clean(value, 32).lower().lstrip(".")
+    return region if region in AMAZON_REGION_SUFFIXES else "com"
+
+
+def _valid_devtools_port(value: object) -> int | None:
+    try:
+        port = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return port if DEVTOOLS_PORT_MIN <= port <= DEVTOOLS_PORT_MAX else None
+
+
+def set_devtools_port(port: object) -> int:
+    """Select a high port explicitly, primarily for an owning runtime instance."""
+
+    global _DEVTOOLS_PORT
+    selected = _valid_devtools_port(port)
+    if selected is None:
+        raise ValueError("DevTools port must be in the private high-port range")
+    _DEVTOOLS_PORT = selected
+    _clear_cache()
+    return selected
+
+
+def reset_devtools_port() -> None:
+    global _DEVTOOLS_PORT, _DISCOVERY_RETRY_AFTER
+    _DEVTOOLS_PORT = None
+    _DISCOVERY_RETRY_AFTER = 0.0
+    _clear_cache()
+
+
+def _reserve_devtools_port(port: object = None) -> tuple[int, socket.socket]:
+    if port is not None:
+        selected = _valid_devtools_port(port)
+        if selected is None:
+            raise ValueError("DevTools port must be in the private high-port range")
+        candidates = [selected]
+    else:
+        candidates = list(range(DEVTOOLS_PORT_MIN, DEVTOOLS_PORT_MAX + 1))
+        random.SystemRandom().shuffle(candidates)
+
+    for candidate in candidates:
+        reservation = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            reservation.bind(("127.0.0.1", candidate))
+            return candidate, reservation
+        except OSError:
+            reservation.close()
+    raise RuntimeError("Could not reserve a private loopback metadata port")
+
+
+def get_devtools_port(create: bool = True) -> int | None:
+    global _DEVTOOLS_PORT
+    if _DEVTOOLS_PORT is None and create:
+        selected, reservation = _reserve_devtools_port()
+        reservation.close()
+        _DEVTOOLS_PORT = selected
+    return _DEVTOOLS_PORT
+
+
+def _read_bundle_info(app_path: Path) -> dict[str, object]:
+    try:
+        with (app_path / "Contents" / "Info.plist").open("rb") as stream:
+            value = plistlib.load(stream)
+    except (OSError, plistlib.InvalidFileException, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _official_signature_identity(app_path: Path, runner=subprocess.run) -> bool:
+    """Check the immutable signing identity without returning codesign output."""
+
+    try:
+        completed = runner(
+            ["/usr/bin/codesign", "-dv", "--verbose=4", str(app_path)],
+            capture_output=True,
+            text=True,
+            timeout=8,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    output = f"{completed.stdout or ''}\n{completed.stderr or ''}"
+    fields: dict[str, list[str]] = {}
+    for raw_line in output.splitlines():
+        key, separator, value = raw_line.partition("=")
+        if separator:
+            fields.setdefault(key.strip(), []).append(value.strip())
+    return bool(
+        completed.returncode == 0
+        and fields.get("Identifier") == [AMAZON_MUSIC_BUNDLE_ID]
+        and fields.get("TeamIdentifier") == [AMAZON_MUSIC_TEAM_ID]
+        and any("AMZN Mobile LLC" in authority for authority in fields.get("Authority", []))
+    )
+
+
+def _validate_app_bundle(
+    app_path: Path,
+    *,
+    require_standard_location: bool = True,
+    signature_checker=_official_signature_identity,
+) -> dict[str, object] | None:
+    try:
+        resolved = app_path.resolve(strict=True)
+    except OSError:
+        return None
+    if require_standard_location and resolved != AMAZON_MUSIC_APP:
+        return None
+    info = _read_bundle_info(resolved)
+    if (
+        info.get("CFBundleIdentifier") != AMAZON_MUSIC_BUNDLE_ID
+        or info.get("CFBundleExecutable") != AMAZON_MUSIC_EXECUTABLE
+    ):
+        return None
+    executable = resolved / "Contents" / "MacOS" / AMAZON_MUSIC_EXECUTABLE
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        return None
+    if signature_checker is not None and not signature_checker(resolved):
+        return None
+    return {
+        "app_path": str(resolved),
+        "executable": str(executable),
+        "bundle_id": AMAZON_MUSIC_BUNDLE_ID,
+        "version": _clean(info.get("CFBundleShortVersionString"), 64),
+    }
+
+
+def locate_amazon_music_app() -> dict[str, object] | None:
+    """Return a validated installation descriptor for the standard app."""
+
+    if sys.platform != "darwin":
+        return None
+    info_path = AMAZON_MUSIC_APP / "Contents" / "Info.plist"
+    executable = AMAZON_MUSIC_APP / "Contents" / "MacOS" / AMAZON_MUSIC_EXECUTABLE
+    try:
+        fingerprint = (
+            info_path.stat().st_mtime_ns,
+            info_path.stat().st_size,
+            executable.stat().st_mtime_ns,
+            executable.stat().st_size,
+        )
+    except OSError:
+        fingerprint = None
+    now = time.monotonic()
+    if (
+        fingerprint is not None
+        and fingerprint == _INSTALLATION_CACHE["fingerprint"]
+        and now < float(cast(float, _INSTALLATION_CACHE["expires"]))
+    ):
+        cached = _INSTALLATION_CACHE["value"]
+        return dict(cached) if isinstance(cached, dict) else None
+    installation = _validate_app_bundle(AMAZON_MUSIC_APP)
+    _INSTALLATION_CACHE.update(
+        {
+            "fingerprint": fingerprint,
+            "expires": now + (60.0 if installation else 3.0),
+            "value": dict(installation) if installation else None,
+        }
+    )
+    return installation
+
+
+def amazon_music_installation_state() -> dict[str, object]:
+    installation = locate_amazon_music_app()
+    if not installation:
+        return {
+            "installed": False,
+            "status": "missing",
+            "detail": "The official Amazon Music app was not found in /Applications",
+        }
+    return {
+        "installed": True,
+        "status": "ready",
+        "detail": "The official Amazon Music app is available",
+        **installation,
+    }
+
+
+def _process_executable_path(pid: int) -> str:
+    if sys.platform != "darwin" or pid <= 0:
+        return ""
+    try:
+        libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+        proc_pidpath = libproc.proc_pidpath
+        proc_pidpath.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint32]
+        proc_pidpath.restype = ctypes.c_int
+        buffer = ctypes.create_string_buffer(4096)
+        length = proc_pidpath(pid, buffer, len(buffer))
+    except (AttributeError, OSError):
+        return ""
+    if length <= 0:
+        return ""
+    return os.fsdecode(buffer.value)
+
+
+def _trusted_process_paths(installation: dict[str, object]) -> frozenset[str]:
+    app_path = Path(str(installation["app_path"]))
+    relatives = (
+        "Contents/MacOS/Amazon Music",
+        "Contents/MacOS/Amazon Music Helper",
+        "Contents/Frameworks/Amazon Music Renderer.app/Contents/MacOS/Amazon Music Renderer",
+        "Contents/Frameworks/Amazon Music Renderer (GPU).app/Contents/MacOS/Amazon Music Renderer (GPU)",
+        "Contents/Frameworks/Amazon Music Renderer (Renderer).app/Contents/MacOS/Amazon Music Renderer (Renderer)",
+    )
+    return frozenset(os.path.realpath(app_path / relative) for relative in relatives)
+
+
+def _is_trusted_amazon_pid(pid: object, installation: dict[str, object]) -> bool:
+    try:
+        selected_pid = int(pid)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return False
+    path = _process_executable_path(selected_pid)
+    return bool(path and os.path.realpath(path) in _trusted_process_paths(installation))
+
+
+def _pids_named(name: str, runner=subprocess.run) -> list[int]:
+    try:
+        completed = runner(
+            ["/usr/bin/pgrep", "-x", name],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if completed.returncode not in (0, 1):
+        return []
+    result = []
+    for line in (completed.stdout or "").splitlines():
+        try:
+            result.append(int(line.strip()))
+        except ValueError:
+            continue
+    return result
+
+
+def _running_amazon_pids(installation: dict[str, object], *, helpers: bool = False) -> list[int]:
+    names = [AMAZON_MUSIC_EXECUTABLE]
+    if helpers:
+        names.extend(
+            [
+                "Amazon Music Helper",
+                "Amazon Music Renderer",
+                "Amazon Music Renderer (GPU)",
+                "Amazon Music Renderer (Renderer)",
+            ]
+        )
+    candidates = {pid for name in names for pid in _pids_named(name)}
+    return sorted(pid for pid in candidates if _is_trusted_amazon_pid(pid, installation))
+
+
+def amazon_music_is_running() -> bool:
+    installation = locate_amazon_music_app()
+    return bool(installation and _running_amazon_pids(installation))
+
+
+def _listener_pids(port: object, runner=subprocess.run) -> list[int]:
+    selected = _valid_devtools_port(port)
+    if selected is None:
+        return []
+    try:
+        completed = runner(
+            [
+                "/usr/sbin/lsof",
+                "-nP",
+                "-a",
+                f"-iTCP:{selected}",
+                "-sTCP:LISTEN",
+                "-Fp",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if completed.returncode != 0:
+        return []
+    pids = set()
+    for line in (completed.stdout or "").splitlines():
+        if line.startswith("p") and line[1:].isdigit():
+            pids.add(int(line[1:]))
+    return sorted(pids)
+
+
+def _trusted_listener_ports(
+    installation: dict[str, object],
+    runner=subprocess.run,
+) -> list[int]:
+    """List private loopback listeners whose every owner is Amazon Music.
+
+    This intentionally asks ``lsof`` only for socket ownership metadata.  It
+    does not inspect Amazon Music's command line, environment, or profile.
+    """
+
+    try:
+        completed = runner(
+            [
+                "/usr/sbin/lsof",
+                "-nP",
+                "-a",
+                "-iTCP",
+                "-sTCP:LISTEN",
+                "-Fpfn",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if completed.returncode != 0:
+        return []
+
+    current_pid: int | None = None
+    owners_by_port: dict[int, set[int]] = {}
+    for line in (completed.stdout or "").splitlines():
+        if line.startswith("p"):
+            current_pid = int(line[1:]) if line[1:].isdigit() else None
+            continue
+        if not line.startswith("n") or current_pid is None:
+            continue
+        endpoint = line[1:]
+        match = re.fullmatch(r"(?:127\.0\.0\.1|\[::1\]):(\d+)", endpoint)
+        if not match:
+            continue
+        selected = _valid_devtools_port(match.group(1))
+        if selected is not None:
+            owners_by_port.setdefault(selected, set()).add(current_pid)
+
+    return sorted(
+        port
+        for port, owners in owners_by_port.items()
+        if owners and all(_is_trusted_amazon_pid(pid, installation) for pid in owners)
+    )
+
+
+def _devtools_owner_trust(port: object, installation: dict[str, object] | None = None) -> dict[str, object]:
+    selected = _valid_devtools_port(port)
+    if selected is None:
+        return {
+            "trusted": False,
+            "status": "rejected",
+            "detail": "The metadata listener port was outside the private high-port range",
+        }
+    installation = installation or locate_amazon_music_app()
+    if not installation:
+        return {
+            "trusted": False,
+            "status": "unavailable",
+            "detail": "The official Amazon Music installation could not be verified",
+        }
+    pids = _listener_pids(selected)
+    if not pids:
+        return {
+            "trusted": False,
+            "status": "unavailable",
+            "detail": "No verifiable Amazon Music metadata listener was found",
+        }
+    if not all(_is_trusted_amazon_pid(pid, installation) for pid in pids):
+        return {
+            "trusted": False,
+            "status": "rejected",
+            "detail": "The metadata port is owned by a non-Amazon process",
+        }
+    return {
+        "trusted": True,
+        "status": "verified",
+        "detail": "The metadata listener belongs to Amazon Music",
+        "pids": pids,
+    }
+
+
+def _http_json(path: str, *, port: object, timeout: float = 1.5) -> object:
+    selected = _valid_devtools_port(port)
+    if selected is None or path not in {"/json", "/json/list", "/json/version"}:
+        raise ConnectionError("Untrusted DevTools HTTP endpoint")
+    connection = http.client.HTTPConnection("127.0.0.1", selected, timeout=max(0.1, timeout))
+    try:
+        connection.request(
+            "GET",
+            path,
+            headers={"Host": f"127.0.0.1:{selected}", "Accept": "application/json", "Connection": "close"},
+        )
+        response = connection.getresponse()
+        if response.status != 200:
+            raise ConnectionError("DevTools HTTP endpoint was unavailable")
+        content_length = response.getheader("Content-Length")
+        if content_length:
+            try:
+                if int(content_length) > MAX_HTTP_RESPONSE_BYTES:
+                    raise ValueError("DevTools HTTP response was too large")
+            except ValueError as error:
+                if str(error) == "DevTools HTTP response was too large":
+                    raise
+        body = response.read(MAX_HTTP_RESPONSE_BYTES + 1)
+        if len(body) > MAX_HTTP_RESPONSE_BYTES:
+            raise ValueError("DevTools HTTP response was too large")
+        return json.loads(body.decode("utf-8"))
+    finally:
+        connection.close()
+
+
+def _exact_https_music_url(value: object) -> str:
+    text = _clean(value, 4096)
+    try:
+        parsed = urlparse(text)
+        port = parsed.port
+    except ValueError:
+        return ""
+    host = (parsed.hostname or "").lower()
+    if (
+        parsed.scheme.lower() != "https"
+        or host not in AMAZON_MUSIC_HOSTS
+        or port not in (None, 443)
+        or parsed.username
+        or parsed.password
+    ):
+        return ""
+    return text
+
+
+def _exact_https_webapp_url(value: object) -> str:
+    """Accept the music site or Amazon's exact legacy Morpho CEF shell."""
+
+    text = _clean(value, 4096)
+    try:
+        parsed = urlparse(text)
+        port = parsed.port
+    except ValueError:
+        return ""
+    host = (parsed.hostname or "").lower()
+    morpho_path = parsed.path.rstrip("/")
+    allowed_morpho = (
+        host in AMAZON_EMBEDDED_WEBAPP_HOSTS
+        and (morpho_path == "/morpho/webapp" or morpho_path.startswith("/morpho/webapp/"))
+    )
+    if (
+        parsed.scheme.lower() != "https"
+        or (host not in AMAZON_MUSIC_HOSTS and not allowed_morpho)
+        or port not in (None, 443)
+        or parsed.username
+        or parsed.password
+    ):
+        return ""
+    return text
+
+
+def _safe_artwork_url(value: object) -> str:
+    text = _clean(value, 4096)
+    try:
+        parsed = urlparse(text)
+        port = parsed.port
+    except ValueError:
+        return ""
+    if (
+        parsed.scheme.lower() != "https"
+        or (parsed.hostname or "").lower() not in AMAZON_IMAGE_HOSTS
+        or port not in (None, 443)
+        or parsed.username
+        or parsed.password
+    ):
+        return ""
+    return text
+
+
+def _is_amazon_music_target(target: object) -> bool:
+    if not isinstance(target, dict) or target.get("type") != "page":
+        return False
+    target_id = _clean(target.get("id"), 256)
+    return bool(_TARGET_ID_RE.fullmatch(target_id) and _exact_https_webapp_url(target.get("url")))
+
+
+def _valid_target_websocket(target: object, port: object) -> bool:
+    selected = _valid_devtools_port(port)
+    if selected is None or not isinstance(target, dict):
+        return False
+    target_id = _clean(target.get("id"), 256)
+    try:
+        parsed = urlparse(_clean(target.get("webSocketDebuggerUrl"), 4096))
+        websocket_port = parsed.port
+    except ValueError:
+        return False
+    match = _DEVTOOLS_PAGE_PATH_RE.fullmatch(parsed.path or "")
+    return bool(
+        parsed.scheme.lower() == "ws"
+        and (parsed.hostname or "").lower() in {"127.0.0.1", "localhost", "::1"}
+        and websocket_port == selected
+        and not parsed.username
+        and not parsed.password
+        and not parsed.params
+        and not parsed.query
+        and not parsed.fragment
+        and match
+        and match.group(1) == target_id
+    )
+
+
+def _page_target(port: object = None, *, verify_owner: bool = True) -> dict[str, object] | None:
+    selected = _valid_devtools_port(port if port is not None else get_devtools_port(False))
+    if selected is None:
+        return None
+    if verify_owner and not _devtools_owner_trust(selected).get("trusted"):
+        return None
+    try:
+        targets = _http_json("/json/list", port=selected)
+    except (ConnectionError, OSError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(targets, list):
+        return None
+    for target in targets:
+        if _is_amazon_music_target(target) and _valid_target_websocket(target, selected):
+            return target
+    return None
+
+
+def discover_devtools_port(installation: dict[str, object] | None = None) -> int | None:
+    """Rediscover one trusted existing Amazon Music DevTools listener.
+
+    A fresh RPC process deliberately does not read Amazon Music's profile or
+    command line.  It considers only loopback listeners owned by processes
+    from the verified official bundle, validates the exposed page target, and
+    fails closed when more than one listener matches.
+    """
+
+    global _DEVTOOLS_PORT, _DISCOVERY_RETRY_AFTER
+    now = time.monotonic()
+    if now < _DISCOVERY_RETRY_AFTER:
+        return None
+    installation = installation or locate_amazon_music_app()
+    if not installation:
+        return None
+
+    matches: list[int] = []
+    for candidate in _trusted_listener_ports(installation):
+        if not _devtools_owner_trust(candidate, installation).get("trusted"):
+            continue
+        if not _page_target(candidate, verify_owner=False):
+            continue
+        # Recheck after probing so a listener ownership race fails closed.
+        if _devtools_owner_trust(candidate, installation).get("trusted"):
+            matches.append(candidate)
+
+    if len(matches) != 1:
+        _DISCOVERY_RETRY_AFTER = time.monotonic() + DISCOVERY_RETRY_SECONDS
+        return None
+    _DEVTOOLS_PORT = matches[0]
+    _DISCOVERY_RETRY_AFTER = 0.0
+    _clear_cache()
+    return _DEVTOOLS_PORT
+
+
+class _CdpSocket:
+    def __init__(self, websocket_url: str, *, expected_port: object, expected_target_id: str, timeout: float = 2.0):
+        target = {"id": expected_target_id, "webSocketDebuggerUrl": websocket_url}
+        if not _valid_target_websocket(target, expected_port):
+            raise ConnectionError("DevTools websocket did not match the trusted page target")
+        parsed = urlparse(websocket_url)
+        self._host = parsed.hostname or "127.0.0.1"
+        self._port = int(parsed.port or 0)
+        self._path = parsed.path
+        self._id = 0
+        self._socket = socket.create_connection((self._host, self._port), timeout=timeout)
+        self._socket.settimeout(timeout)
+        self._handshake()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+        return False
+
+    def close(self) -> None:
+        try:
+            self._send_frame(b"", opcode=8)
+        except Exception:
+            pass
+        try:
+            self._socket.close()
+        except Exception:
+            pass
+
+    def _read_exact(self, length: int) -> bytes:
+        chunks = []
+        remaining = length
+        while remaining:
+            chunk = self._socket.recv(remaining)
+            if not chunk:
+                raise ConnectionError("DevTools websocket closed")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def _handshake(self) -> None:
+        key = base64.b64encode(os.urandom(16)).decode("ascii")
+        request = (
+            f"GET {self._path} HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{self._port}\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\n"
+            "Sec-WebSocket-Version: 13\r\n\r\n"
+        )
+        self._socket.sendall(request.encode("ascii"))
+        response = b""
+        while b"\r\n\r\n" not in response:
+            response += self._socket.recv(4096)
+            if len(response) > MAX_HANDSHAKE_BYTES:
+                raise ConnectionError("DevTools websocket handshake was too large")
+        status_line, _, header_block = response.partition(b"\r\n")
+        if b" 101 " not in status_line:
+            raise ConnectionError("DevTools websocket handshake failed")
+        headers: dict[bytes, bytes] = {}
+        for line in header_block.split(b"\r\n"):
+            name, separator, value = line.partition(b":")
+            if separator:
+                headers[name.strip().lower()] = value.strip()
+        expected = base64.b64encode(
+            hashlib.sha1(
+                (key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode("ascii"),
+                usedforsecurity=False,
+            ).digest()
+        )
+        if headers.get(b"sec-websocket-accept") != expected:
+            raise ConnectionError("DevTools websocket accept key did not match")
+
+    def _send_frame(self, payload: str | bytes, *, opcode: int = 1) -> None:
+        data = payload if isinstance(payload, bytes) else payload.encode("utf-8")
+        if len(data) > MAX_WEBSOCKET_MESSAGE_BYTES:
+            raise ValueError("DevTools request was too large")
+        header = bytearray([0x80 | opcode])
+        if len(data) < 126:
+            header.append(0x80 | len(data))
+        elif len(data) <= 0xFFFF:
+            header.extend((0x80 | 126,))
+            header.extend(struct.pack("!H", len(data)))
+        else:
+            header.extend((0x80 | 127,))
+            header.extend(struct.pack("!Q", len(data)))
+        mask = os.urandom(4)
+        header.extend(mask)
+        masked = bytes(byte ^ mask[index % 4] for index, byte in enumerate(data))
+        self._socket.sendall(bytes(header) + masked)
+
+    def _recv_frame(self) -> tuple[int, bytes]:
+        first, second = self._read_exact(2)
+        if not first & 0x80:
+            raise ConnectionError("Fragmented DevTools websocket frame was rejected")
+        if second & 0x80:
+            raise ConnectionError("Masked DevTools server frame was rejected")
+        opcode = first & 0x0F
+        length = second & 0x7F
+        if length == 126:
+            length = struct.unpack("!H", self._read_exact(2))[0]
+        elif length == 127:
+            length = struct.unpack("!Q", self._read_exact(8))[0]
+        if length > MAX_WEBSOCKET_MESSAGE_BYTES:
+            raise ConnectionError("DevTools websocket message was too large")
+        return opcode, self._read_exact(length) if length else b""
+
+    def request(self, method: str, params: dict[str, object] | None = None) -> dict[str, object]:
+        self._id += 1
+        request_id = self._id
+        self._send_frame(json.dumps({"id": request_id, "method": method, "params": params or {}}))
+        while True:
+            opcode, payload = self._recv_frame()
+            if opcode == 8:
+                raise ConnectionError("DevTools websocket closed")
+            if opcode == 9:
+                self._send_frame(payload, opcode=10)
+                continue
+            if opcode == 10:
+                continue
+            if opcode != 1:
+                raise ConnectionError("Unexpected DevTools websocket frame")
+            message = json.loads(payload.decode("utf-8"))
+            if isinstance(message, dict) and message.get("id") == request_id:
+                return message
+
+
+_TRANSPORT_EXPRESSION = r"""
+(() => {
+  const clean = (value, limit = 2048) => String(value || '').replace(/\s+/g, ' ').trim().slice(0, limit);
+  const root = document.querySelector('#transportContainer.hasTrackLoaded') ||
+    document.querySelector('#transportContainer') || document.querySelector('#transport');
+  if (!root) {
+    return {status: 'no_match', detail: 'Amazon Music transport was not found'};
+  }
+  const first = (...selectors) => selectors.map((selector) => root.querySelector(selector)).find(Boolean) || null;
+  const text = (element) => element ? clean(element.getAttribute('title') || element.innerText || element.textContent) : '';
+  const titleElement = first('.trackMetadataWrapper .primaryContainer', '.trackMetadata .primaryContainer',
+    '.trackMetadata .title', '[data-testid="transport-title"]');
+  const secondaryElement = first('.trackMetadataWrapper .secondaryText', '.trackMetadata .secondaryText');
+  const secondaryParts = Array.from(root.querySelectorAll(
+    '.trackMetadataWrapper .secondaryInnerText, .trackMetadata .secondaryInnerText'
+  )).map(text).filter(Boolean).slice(0, 2);
+  const image = first('.trackMetadataWrapper .albumArt img.artImage', '.albumArt img.artImage', 'img.artImage');
+  const titleLink = titleElement ?
+    (titleElement.matches('a[href]') ? titleElement : titleElement.querySelector('a[href]')) : null;
+  const positionElement = first('.currentPlaybackPosition');
+  const remainingElement = first('.currentRemainingPosition');
+  const playPause = first('button.playPause');
+  const media = document.querySelector('audio, video');
+  let playbackStatus = '';
+  if (media && clean(media.currentSrc || media.src)) {
+    playbackStatus = media.paused ? 'paused' : 'playing';
+  } else {
+    const markup = playPause ? clean(playPause.innerHTML, 8192) : '';
+    if (/#pause|svg-icon--pause/i.test(markup)) playbackStatus = 'playing';
+    else if (/#play|svg-icon--play/i.test(markup)) playbackStatus = 'paused';
+  }
+  const finite = (value) => Number.isFinite(Number(value)) ? Number(value) : null;
+  const title = text(titleElement);
+  const secondary = text(secondaryElement);
+  return {
+    status: title && (secondaryParts[0] || secondary) ? 'found' : 'no_match',
+    detail: title ? 'Amazon Music transport found' : 'Amazon Music transport had no title',
+    title,
+    artist: secondaryParts[0] || '',
+    album: secondaryParts[1] || '',
+    secondary,
+    art_url: image ? clean(image.currentSrc || image.src, 4096) : '',
+    track_link: titleLink ? clean(titleLink.href, 4096) : '',
+    position: media ? finite(media.currentTime) : null,
+    duration: media ? finite(media.duration) : null,
+    position_text: text(positionElement),
+    remaining_text: text(remainingElement),
+    playback_status: playbackStatus
+  };
+})()
+"""
+
+
+def _seconds(value: object) -> float | None:
+    try:
+        number = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return max(0.0, number) if math.isfinite(number) else None
+
+
+def _parse_time(value: object) -> int | None:
+    text = _clean(value, 16)
+    if not _TIME_RE.fullmatch(text):
+        return None
+    negative = text.startswith("-")
+    if negative:
+        text = text[1:]
+    parts = [int(part) for part in text.split(":")]
+    seconds = parts[0] * 60 + parts[1] if len(parts) == 2 else parts[0] * 3600 + parts[1] * 60 + parts[2]
+    return -seconds if negative else seconds
+
+
+def amazon_music_search_link(title: object, artist: object, link_region: object = None) -> str:
+    query = " ".join(part for part in (_clean(title, 512), _clean(artist, 512)) if part)
+    if not query:
+        return ""
+    return f"https://music.amazon.{_normalise_region(link_region)}/search/{quote(query, safe='')}"
+
+
+def _track_link(payload: dict[str, object], title: str, artist: str, link_region: object = None) -> str:
+    asin = _clean(payload.get("track_asin"), 16).upper()
+    if _ASIN_RE.fullmatch(asin):
+        return f"https://music.amazon.{_normalise_region(link_region)}/tracks/{asin}"
+    direct = _exact_https_music_url(payload.get("track_link"))
+    return direct or amazon_music_search_link(title, artist, link_region)
+
+
+def _normalise_track_payload(payload: object, link_region: object = None) -> dict[str, object]:
+    if not isinstance(payload, dict):
+        return {
+            "status": "no_match",
+            "detail": "No Amazon Music transport metadata was returned",
+            "source": "amazon_devtools",
+        }
+    if payload.get("status") != "found":
+        return {
+            "status": "no_match",
+            "detail": "Amazon Music does not currently have a track loaded",
+            "source": "amazon_devtools",
+        }
+    title = _clean_label(payload.get("title"))
+    artist = _clean(payload.get("artist"), 512)
+    album = _clean_label(payload.get("album"))
+    secondary = _clean(payload.get("secondary"), 1024)
+    if secondary and (not artist or not album):
+        if " • " in secondary:
+            left, right = secondary.split(" • ", 1)
+            artist = artist or _clean(left, 512)
+            album = album or _clean_label(right)
+        elif not artist:
+            artist = secondary[:512]
+    if not title or not artist:
+        return {
+            "status": "no_match",
+            "detail": "Amazon Music transport metadata was incomplete",
+            "source": "amazon_devtools",
+        }
+
+    position = _seconds(payload.get("position"))
+    duration = _seconds(payload.get("duration"))
+    if position is None:
+        parsed_position = _parse_time(payload.get("position_text"))
+        position = float(parsed_position) if parsed_position is not None and parsed_position >= 0 else None
+    if not duration:
+        remaining = _parse_time(payload.get("remaining_text"))
+        if position is not None and remaining is not None and remaining < 0:
+            duration = position + abs(remaining)
+    if duration and position is not None:
+        position = min(position, duration)
+
+    playback_status = _clean(payload.get("playback_status"), 16).lower()
+    if playback_status not in {"playing", "paused"}:
+        playback_status = "playing"
+    return {
+        "status": "found",
+        "detail": "Amazon Music metadata found",
+        "source": "amazon_devtools",
+        "title": title,
+        "artist": artist,
+        "album": album,
+        "art_url": _safe_artwork_url(payload.get("art_url")),
+        "track_link": _track_link(payload, title, artist, link_region),
+        "position": position,
+        "duration": duration or 0.0,
+        "playback_status": playback_status,
+        "confidence": 98,
+    }
+
+
+def get_devtools_status(port: object = None) -> dict[str, object]:
+    selected = _valid_devtools_port(port if port is not None else get_devtools_port(False))
+    installation = locate_amazon_music_app()
+    if not installation:
+        return {
+            "status": "missing",
+            "detail": "The official Amazon Music app was not found",
+            "source": "amazon_devtools",
+        }
+    running = bool(_running_amazon_pids(installation))
+    if selected is None and port is None:
+        selected = discover_devtools_port(installation)
+    if selected is None:
+        return {
+            "status": "off" if not running else "restart_required",
+            "detail": "Amazon Music is not running with enhanced metadata",
+            "source": "amazon_devtools",
+            "running": running,
+        }
+    owner = _devtools_owner_trust(selected, installation)
+    if not owner.get("trusted"):
+        return {
+            "status": owner.get("status", "unavailable"),
+            "detail": owner.get("detail", "Amazon Music enhanced metadata is unavailable"),
+            "source": "amazon_devtools",
+            "port": selected,
+            "running": running,
+        }
+    target = _page_target(selected, verify_owner=False)
+    if not target:
+        return {
+            "status": "starting" if running else "unavailable",
+            "detail": "Waiting for a validated Amazon Music page target",
+            "source": "amazon_devtools",
+            "port": selected,
+            "running": running,
+        }
+    return {
+        "status": "ready",
+        "detail": "Amazon Music enhanced metadata is ready",
+        "source": "amazon_devtools",
+        "port": selected,
+        "running": True,
+        "owner": owner,
+    }
+
+
+def get_devtools_track_sync(
+    link_region: object = None,
+    port: object = None,
+    method: str = "",
+) -> dict[str, object]:
+    selected = _valid_devtools_port(port if port is not None else get_devtools_port(False))
+    if selected is None and port is None:
+        selected = discover_devtools_port()
+    if selected is None:
+        return {
+            "status": "unavailable",
+            "detail": "Amazon Music enhanced metadata has not been started",
+            "source": "amazon_devtools",
+        }
+    owner = _devtools_owner_trust(selected)
+    if not owner.get("trusted"):
+        return {
+            "status": "error" if owner.get("status") == "rejected" else "unavailable",
+            "detail": owner.get("detail", "Amazon Music enhanced metadata is unavailable"),
+            "source": "amazon_devtools",
+            "port": selected,
+        }
+    target = _page_target(selected, verify_owner=False)
+    if not target:
+        return {
+            "status": "unavailable",
+            "detail": "No validated Amazon Music page target was found",
+            "source": "amazon_devtools",
+            "port": selected,
+        }
+    if not _devtools_owner_trust(selected).get("trusted"):
+        return {
+            "status": "error",
+            "detail": "The Amazon Music metadata listener owner changed",
+            "source": "amazon_devtools",
+            "port": selected,
+        }
+
+    cache_key = f"{selected}|{target.get('id')}|{_normalise_region(link_region)}"
+    now = time.monotonic()
+    if _CACHE["key"] == cache_key and now < float(cast(float, _CACHE["expires"])):
+        cached = _CACHE["value"]
+        return dict(cached) if isinstance(cached, dict) else cached  # type: ignore[return-value]
+
+    try:
+        with _CdpSocket(
+            str(target["webSocketDebuggerUrl"]),
+            expected_port=selected,
+            expected_target_id=str(target["id"]),
+        ) as client:
+            response = client.request(
+                "Runtime.evaluate",
+                {
+                    "expression": _TRANSPORT_EXPRESSION,
+                    "returnByValue": True,
+                    "awaitPromise": False,
+                    "includeCommandLineAPI": False,
+                    "userGesture": False,
+                },
+            )
+        if response.get("error") or response.get("result", {}).get("exceptionDetails"):  # type: ignore[union-attr]
+            raise RuntimeError("CDP evaluation failed")
+        result = response.get("result", {}).get("result", {}).get("value")  # type: ignore[union-attr]
+        track = _normalise_track_payload(result, link_region)
+        track["port"] = selected
+        if method:
+            track["method"] = _clean(method, 64)
+        elif _LAST_LAUNCH.get("port") == selected:
+            track["method"] = _clean(_LAST_LAUNCH.get("method"), 64)
+    except (ConnectionError, OSError, ValueError, KeyError, json.JSONDecodeError, RuntimeError, TypeError):
+        track = {
+            "status": "error",
+            "detail": "Amazon Music did not return safe transport metadata",
+            "source": "amazon_devtools",
+            "port": selected,
+        }
+    _CACHE.update({"key": cache_key, "expires": now + 1.0, "value": dict(track)})
+    return track
+
+
+def _clear_cache() -> None:
+    _CACHE.update({"key": None, "expires": 0.0, "value": None})
+
+
+def apply_devtools_to_track(track: object, devtools: object) -> tuple[dict[str, object], bool]:
+    merged = dict(track) if isinstance(track, dict) else {}
+    if not isinstance(devtools, dict) or devtools.get("status") != "found":
+        return merged, False
+    changed = False
+    for key in ("title", "artist", "album"):
+        value = _clean(devtools.get(key), 512)
+        if value and value != merged.get(key):
+            merged[key] = value
+            changed = True
+    if devtools.get("position") is not None:
+        merged["position"] = devtools["position"]
+    if devtools.get("duration"):
+        merged["duration"] = devtools["duration"]
+    if devtools.get("playback_status") in {"playing", "paused"}:
+        merged["status"] = devtools["playback_status"]
+    if devtools.get("art_url"):
+        merged["_amazon_art_url"] = devtools["art_url"]
+    if devtools.get("track_link"):
+        merged["_amazon_track_link"] = devtools["track_link"]
+    return merged, changed
+
+
+def _wait_for_page_target(
+    port: int,
+    timeout: float,
+    installation: dict[str, object] | None = None,
+) -> dict[str, object] | None:
+    deadline = time.monotonic() + max(0.1, timeout)
+    while time.monotonic() < deadline:
+        if _devtools_owner_trust(port, installation).get("trusted"):
+            target = _page_target(port, verify_owner=False)
+            if target:
+                return target
+        time.sleep(0.25)
+    return None
+
+
+def _launch_process(installation: dict[str, object], arguments: list[str], popen=subprocess.Popen):
+    executable = str(installation["executable"])
+    return popen(
+        [executable, *arguments],
+        cwd=str(Path(executable).parent),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+        start_new_session=True,
+    )
+
+
+def _terminate_failed_launch(process: object, installation: dict[str, object]) -> None:
+    """Best-effort cleanup so a failed launch does not leave CDP exposed."""
+
+    try:
+        pid = int(getattr(process, "pid"))
+    except (TypeError, ValueError, AttributeError):
+        reset_devtools_port()
+        return
+    if _is_trusted_amazon_pid(pid, installation):
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+    reset_devtools_port()
+
+
+def launch_amazon_music_devtools(*, port: object = None, wait_timeout: float = 12.0) -> dict[str, object]:
+    """Launch Amazon Music with CDP, or request an explicit restart if open."""
+
+    global _DEVTOOLS_PORT
+    installation = locate_amazon_music_app()
+    if not installation:
+        return {"ok": False, "status": "missing", "error": "The official Amazon Music app was not found"}
+    if _running_amazon_pids(installation):
+        selected = _valid_devtools_port(port if port is not None else get_devtools_port(False))
+        if selected is None and port is None:
+            selected = discover_devtools_port(installation)
+        if selected and _page_target(selected):
+            return {"ok": True, "status": "ready", "already_running": True, "port": selected}
+        return {
+            "ok": False,
+            "status": "restart_required",
+            "restart_required": True,
+            "error": "Amazon Music must be restarted once to enable enhanced metadata",
+        }
+    try:
+        selected, reservation = _reserve_devtools_port(port)
+    except (RuntimeError, ValueError) as error:
+        return {"ok": False, "status": "error", "error": str(error)}
+    _DEVTOOLS_PORT = selected
+    _clear_cache()
+    reservation.close()
+    try:
+        process = _launch_process(
+            installation,
+            ["--remote-debugging-address=127.0.0.1", f"--remote-debugging-port={selected}"],
+        )
+    except (OSError, subprocess.SubprocessError):
+        reset_devtools_port()
+        return {"ok": False, "status": "error", "error": "Could not launch Amazon Music"}
+    target = _wait_for_page_target(selected, wait_timeout, installation)
+    if not target:
+        _terminate_failed_launch(process, installation)
+        return {
+            "ok": False,
+            "status": "error",
+            "error": "Amazon Music did not expose a validated metadata page",
+            "port": selected,
+            "pid": int(process.pid),
+        }
+    owner = _devtools_owner_trust(selected, installation)
+    if not owner.get("trusted"):
+        _terminate_failed_launch(process, installation)
+        return {
+            "ok": False,
+            "status": "error",
+            "error": owner.get("detail", "The metadata listener could not be verified"),
+            "port": selected,
+        }
+    _LAST_LAUNCH.clear()
+    _LAST_LAUNCH.update({"port": selected, "pid": int(process.pid), "method": "direct-executable"})
+    return {
+        "ok": True,
+        "status": "ready",
+        "port": selected,
+        "pid": int(process.pid),
+        "method": "direct-executable",
+        "owner": owner,
+    }
+
+
+def stop_amazon_music(*, timeout: float = 8.0) -> dict[str, object]:
+    installation = locate_amazon_music_app()
+    if not installation:
+        return {"ok": False, "status": "missing", "error": "The official Amazon Music app was not found", "stopped": []}
+    pids = _running_amazon_pids(installation, helpers=True)
+    if not pids:
+        return {"ok": True, "status": "stopped", "stopped": []}
+    for pid in pids:
+        if not _is_trusted_amazon_pid(pid, installation):
+            continue
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except (OSError, ProcessLookupError):
+            pass
+    deadline = time.monotonic() + max(0.1, timeout)
+    remaining = pids
+    while remaining and time.monotonic() < deadline:
+        time.sleep(0.1)
+        remaining = [pid for pid in _running_amazon_pids(installation, helpers=True) if pid in pids]
+    for pid in remaining:
+        if not _is_trusted_amazon_pid(pid, installation):
+            continue
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except (OSError, ProcessLookupError):
+            pass
+    _clear_cache()
+    return {"ok": True, "status": "stopped", "stopped": pids, "forced": bool(remaining)}
+
+
+def restart_amazon_music_devtools(*, wait_timeout: float = 12.0) -> dict[str, object]:
+    stop_result = stop_amazon_music()
+    if not stop_result.get("ok"):
+        return stop_result
+    reset_devtools_port()
+    launch_result = launch_amazon_music_devtools(wait_timeout=wait_timeout)
+    return {**launch_result, "stopped": stop_result.get("stopped", [])}
+
+
+def disable_amazon_music_devtools(*, relaunch: bool = True) -> dict[str, object]:
+    """Remove the listener by stopping Amazon Music, optionally reopening normally."""
+
+    installation = locate_amazon_music_app()
+    if not installation:
+        return {"ok": False, "status": "missing", "error": "The official Amazon Music app was not found"}
+    stop_result = stop_amazon_music()
+    if not stop_result.get("ok"):
+        return stop_result
+    reset_devtools_port()
+    _LAST_LAUNCH.clear()
+    if not relaunch:
+        return {"ok": True, "status": "stopped", "stopped": stop_result.get("stopped", [])}
+    try:
+        process = _launch_process(installation, [])
+    except (OSError, subprocess.SubprocessError):
+        return {"ok": False, "status": "error", "error": "Could not reopen Amazon Music without enhanced metadata"}
+    return {
+        "ok": True,
+        "status": "disabled",
+        "pid": int(process.pid),
+        "stopped": stop_result.get("stopped", []),
+    }

--- a/MacOS/amazon_music_now_playing.js
+++ b/MacOS/amazon_music_now_playing.js
@@ -1,0 +1,73 @@
+ObjC.import('Foundation');
+
+function jsValue(value) {
+  try {
+    return ObjC.unwrap(value);
+  } catch (error) {
+    return value;
+  }
+}
+
+function textValue(value) {
+  if (value === undefined || value === null) return '';
+  try {
+    return String(jsValue(value));
+  } catch (error) {
+    return '';
+  }
+}
+
+function numberValue(value) {
+  const number = Number(jsValue(value));
+  return Number.isFinite(number) ? number : null;
+}
+
+function run() {
+  const mediaRemote = $.NSBundle.bundleWithPath(
+    '/System/Library/PrivateFrameworks/MediaRemote.framework/'
+  );
+  if (!mediaRemote || !mediaRemote.load) {
+    return JSON.stringify({status: 'framework_unavailable'});
+  }
+
+  const request = $.NSClassFromString('MRNowPlayingRequest');
+  if (!request) return JSON.stringify({status: 'request_unavailable'});
+
+  const playerPath = request.localNowPlayingPlayerPath;
+  const client = playerPath ? playerPath.client : null;
+  const bundleIdentifier = client ? textValue(client.bundleIdentifier) : '';
+  if (bundleIdentifier !== 'com.amazon.music') {
+    return JSON.stringify({
+      status: 'not_amazon_music',
+      bundle_identifier: bundleIdentifier,
+    });
+  }
+
+  const item = request.localNowPlayingItem;
+  if (!item) {
+    return JSON.stringify({
+      status: 'no_item',
+      bundle_identifier: bundleIdentifier,
+    });
+  }
+
+  const info = item.nowPlayingInfo;
+  const metadata = item.metadata;
+  const infoValue = key => info ? info.valueForKey(key) : null;
+  const playbackRate = metadata ? numberValue(metadata.playbackRate) : null;
+
+  return JSON.stringify({
+    status: 'found',
+    bundle_identifier: bundleIdentifier,
+    display_name: client ? textValue(client.displayName) : '',
+    title: textValue(infoValue('kMRMediaRemoteNowPlayingInfoTitle')),
+    artist: textValue(infoValue('kMRMediaRemoteNowPlayingInfoArtist')),
+    album: textValue(infoValue('kMRMediaRemoteNowPlayingInfoAlbum')),
+    duration: metadata ? numberValue(metadata.duration) : null,
+    position: metadata ? numberValue(metadata.calculatedPlaybackPosition) : null,
+    playback_rate: playbackRate,
+    playback_status: playbackRate !== null && playbackRate > 0 ? 'playing' : 'paused',
+    artwork_url: textValue(infoValue('kMRMediaRemoteNowPlayingInfoArtworkIdentifier')),
+    artwork_mime_type: metadata ? textValue(metadata.artworkMIMEType) : '',
+  });
+}

--- a/MacOS/config.py
+++ b/MacOS/config.py
@@ -1,0 +1,439 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+"""macOS configuration, Keychain secrets, and login-item integration."""
+
+from __future__ import annotations
+
+import json
+import os
+import plistlib
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import fcntl
+
+
+APP_NAME = "AmazonMusicRPC"
+APP_DISPLAY_NAME = "Amazon Music RPC"
+APP_VERSION = "5.0.0-macos-beta.1"
+BUNDLE_IDENTIFIER = "io.github.eripum9.amazon-music-rpc"
+DEFAULT_CLIENT_ID = "1479925587697995857"
+CONFIG_REVISION_KEY = "_revision"
+
+CONFIG_DIR = str(Path.home() / "Library" / "Application Support" / APP_NAME)
+CONFIG_PATH = str(Path(CONFIG_DIR) / "config.json")
+LOG_PATH = str(Path(CONFIG_DIR) / "console.log")
+EVENT_LOG_PATH = str(Path(CONFIG_DIR) / "events.jsonl")
+DIAGNOSTICS_PATH = str(Path(CONFIG_DIR) / "diagnostics.json")
+LAUNCH_AGENT_PATH = str(Path.home() / "Library" / "LaunchAgents" / f"{BUNDLE_IDENTIFIER}.plist")
+KEYCHAIN_SERVICE = BUNDLE_IDENTIFIER
+
+AMAZON_MUSIC_LINK_REGIONS = (
+    "com",
+    "de",
+    "co.uk",
+    "fr",
+    "it",
+    "es",
+    "co.jp",
+    "ca",
+    "com.au",
+    "com.br",
+    "com.mx",
+)
+DISCORD_STATUS_DISPLAY_MODES = ("application", "artist", "album", "track")
+
+DEFAULTS = {
+    "discord_client_id": DEFAULT_CLIENT_ID,
+    "use_custom_client_id": False,
+    "discord_status_display": "artist",
+    "start_on_startup": False,
+    "start_minimized": True,
+    "track_mappings": {},
+    "custom_albums": [],
+    "song_link_enabled": True,
+    "song_link_provider": "amazon",
+    "amazon_music_link_region": "com",
+    "show_paused": True,
+    "lastfm_enabled": False,
+    "lastfm_api_key": "2c2d97048ae5546831b1b1a025a8f9ec",
+    "lastfm_api_secret": "5d9fecd9d4836815d5c1f05cde9a611c",
+    "lastfm_session_key": "",
+    "lastfm_username": "",
+    "listenbrainz_enabled": False,
+    "listenbrainz_token": "",
+    "amazon_devtools_enabled": True,
+    "amazon_devtools_auto_launch": False,
+    "amazon_devtools_port": 0,
+    "privacy_private_session": False,
+    "privacy_blocked_keywords": "",
+    "privacy_disable_scrobbling": True,
+    "game_mode_enabled": False,
+    "game_mode_processes": "",
+    "intro_seen": False,
+    "setup_wizard_seen": False,
+    "setup_wizard_version": "",
+    "settings_window_width": 760,
+    "settings_window_height": 720,
+    "diagnostics_window_width": 940,
+    "diagnostics_window_height": 700,
+    "automatic_update_checks": True,
+    "deezer_lookup_enabled": True,
+    "itunes_lookup_enabled": True,
+}
+
+SENSITIVE_CONFIG_KEYS = {
+    "lastfm_session_key",
+    "lastfm_api_secret",
+    "listenbrainz_token",
+}
+REDACTION_TEXT = "[redacted]"
+SENSITIVE_TEXT_PATTERNS = (
+    re.compile(
+        r'("(?:lastfm_session_key|lastfm_api_secret|listenbrainz_token)"\s*:\s*")([^"]+)(")',
+        re.IGNORECASE,
+    ),
+    re.compile(r"(\bToken\s+)([A-Za-z0-9._~+/=-]{6,})", re.IGNORECASE),
+    re.compile(r"(\bAuthorization\s*:\s*Token\s+)([A-Za-z0-9._~+/=-]{6,})", re.IGNORECASE),
+)
+
+_CONFIG_THREAD_LOCK = threading.RLock()
+
+
+class ConfigConflictError(RuntimeError):
+    pass
+
+
+def normalize_amazon_music_link_region(value):
+    text = str(value or "").strip().lower().lstrip(".")
+    return text if text in AMAZON_MUSIC_LINK_REGIONS else "com"
+
+
+def normalize_discord_status_display(value):
+    text = str(value or "").strip().lower()
+    return text if text in DISCORD_STATUS_DISPLAY_MODES else "artist"
+
+
+def _complete_config(saved):
+    saved = saved if isinstance(saved, dict) else {}
+    config = {**DEFAULTS, **saved}
+    config["amazon_music_link_region"] = normalize_amazon_music_link_region(
+        config.get("amazon_music_link_region")
+    )
+    config["discord_status_display"] = normalize_discord_status_display(
+        config.get("discord_status_display")
+    )
+    try:
+        config[CONFIG_REVISION_KEY] = max(0, int(saved.get(CONFIG_REVISION_KEY, 0)))
+    except (TypeError, ValueError):
+        config[CONFIG_REVISION_KEY] = 0
+    return config
+
+
+def _atomic_write(path, payload, mode=0o600):
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=target.parent)
+    try:
+        os.fchmod(fd, mode)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _atomic_write_json(path, payload):
+    _atomic_write(path, json.dumps(payload, indent=2, ensure_ascii=False).encode("utf-8"))
+
+
+@contextmanager
+def _exclusive_config_lock(timeout=10):
+    lock_path = Path(str(CONFIG_PATH) + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with _CONFIG_THREAD_LOCK, lock_path.open("a+b") as handle:
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("Timed out waiting for the configuration lock")
+                time.sleep(0.05)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _security(args, *, input_text=None, timeout=8):
+    try:
+        return subprocess.run(
+            ["/usr/bin/security", *args],
+            input=input_text,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _keychain_read(key):
+    result = _security(
+        ["find-generic-password", "-a", str(key), "-s", KEYCHAIN_SERVICE, "-w"]
+    )
+    if not result or result.returncode != 0:
+        return ""
+    return (result.stdout or "").rstrip("\r\n")
+
+
+def _keychain_write(key, value):
+    value = str(value or "")
+    if not value:
+        return _keychain_delete(key)
+    result = _security(
+        [
+            "add-generic-password",
+            "-U",
+            "-a",
+            str(key),
+            "-s",
+            KEYCHAIN_SERVICE,
+            "-w",
+            value,
+        ]
+    )
+    return bool(result and result.returncode == 0)
+
+
+def _keychain_delete(key):
+    result = _security(
+        ["delete-generic-password", "-a", str(key), "-s", KEYCHAIN_SERVICE]
+    )
+    return bool(result is None or result.returncode in (0, 44))
+
+
+def _read_public_config():
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _public_config(config):
+    return {
+        key: value
+        for key, value in dict(config or {}).items()
+        if key not in SENSITIVE_CONFIG_KEYS
+    }
+
+
+def _load_config_locked():
+    public = _read_public_config()
+    # Migrate any pre-Keychain prototype files without retaining plaintext secrets.
+    migrated = False
+    for key in SENSITIVE_CONFIG_KEYS:
+        legacy = str(public.pop(key, "") or "")
+        if legacy:
+            _keychain_write(key, legacy)
+            migrated = True
+    if migrated:
+        _atomic_write_json(CONFIG_PATH, public)
+    secrets = {key: _keychain_read(key) for key in SENSITIVE_CONFIG_KEYS}
+    return _complete_config({**public, **{k: v for k, v in secrets.items() if v}})
+
+
+def load_config():
+    with _exclusive_config_lock():
+        return _load_config_locked()
+
+
+def load_config_for_update():
+    return load_config()
+
+
+def _stored_revision(config):
+    try:
+        return max(0, int((config or {}).get(CONFIG_REVISION_KEY, 0)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _persist_config_locked(config, revision):
+    persisted = _complete_config(config)
+    persisted[CONFIG_REVISION_KEY] = int(revision)
+    for key in SENSITIVE_CONFIG_KEYS:
+        if key in persisted and not _keychain_write(key, persisted.get(key, "")):
+            raise OSError(f"Could not store {key} in macOS Keychain")
+    _atomic_write_json(CONFIG_PATH, _public_config(persisted))
+    return persisted
+
+
+def save_config(config):
+    with _exclusive_config_lock():
+        current = _load_config_locked()
+        current_revision = _stored_revision(current)
+        expected = (config or {}).get(CONFIG_REVISION_KEY)
+        if Path(CONFIG_PATH).exists() and expected is None:
+            raise ConfigConflictError("Whole-configuration saves require a revision")
+        if expected is not None and int(expected) != current_revision:
+            raise ConfigConflictError(
+                f"Configuration changed from revision {expected} to {current_revision}"
+            )
+        return _persist_config_locked(config, current_revision + 1)
+
+
+def update_config_fields(updates, expected_revision=None):
+    if not isinstance(updates, dict):
+        raise TypeError("Configuration updates must be a dictionary")
+    invalid = set(updates).difference(DEFAULTS)
+    if invalid:
+        raise KeyError(f"Unsupported configuration fields: {', '.join(sorted(invalid))}")
+    with _exclusive_config_lock():
+        current = _load_config_locked()
+        current_revision = _stored_revision(current)
+        if expected_revision is not None and int(expected_revision) > current_revision:
+            raise ConfigConflictError("Configuration revision is newer than the stored revision")
+        current.update(updates)
+        return _persist_config_locked(current, current_revision + 1)
+
+
+def mutate_config_fields(fields, transform):
+    allowed = set(fields or ())
+    if not allowed or allowed.difference(DEFAULTS):
+        raise KeyError("Configuration mutation fields must be known settings")
+    with _exclusive_config_lock():
+        current = _load_config_locked()
+        proposed = transform({key: current.get(key) for key in allowed})
+        if not isinstance(proposed, dict) or set(proposed).difference(allowed):
+            raise ValueError("Configuration mutation changed fields outside its declared scope")
+        current.update(proposed)
+        return _persist_config_locked(current, _stored_revision(current) + 1)
+
+
+def credential_storage_status():
+    available = Path("/usr/bin/security").exists()
+    keys = [key for key in sorted(SENSITIVE_CONFIG_KEYS) if available and _keychain_read(key)]
+    return {
+        "keychain_available": available,
+        "keychain_keys": keys,
+        "credential_manager_available": available,
+        "credential_manager_keys": keys,
+        "dpapi_fallback_keys": [],
+    }
+
+
+def clear_sensitive_credentials():
+    with _exclusive_config_lock():
+        removed = all(_keychain_delete(key) for key in SENSITIVE_CONFIG_KEYS)
+        public = _read_public_config()
+        if public:
+            public[CONFIG_REVISION_KEY] = _stored_revision(public) + 1
+            _atomic_write_json(CONFIG_PATH, _public_config(public))
+        return removed
+
+
+def migrate_sensitive_config():
+    with _exclusive_config_lock():
+        before = _read_public_config()
+        had_secrets = any(key in before for key in SENSITIVE_CONFIG_KEYS)
+        _load_config_locked()
+        return had_secrets
+
+
+def _sensitive_values(config=None):
+    values = set()
+    for source in (DEFAULTS, config or {}):
+        for key in SENSITIVE_CONFIG_KEYS:
+            value = str(source.get(key, "") or "")
+            if len(value) >= 6:
+                values.add(value)
+    return values
+
+
+def redact_text(value, config=None):
+    text = str(value or "")
+    for pattern in SENSITIVE_TEXT_PATTERNS:
+        text = pattern.sub(
+            lambda match: f"{match.group(1)}{REDACTION_TEXT}{match.group(3) if len(match.groups()) > 2 else ''}",
+            text,
+        )
+    for secret in sorted(_sensitive_values(config), key=len, reverse=True):
+        text = text.replace(secret, REDACTION_TEXT)
+    return text
+
+
+def redact_data(value, config=None):
+    if isinstance(value, dict):
+        return {
+            key: REDACTION_TEXT if str(key).lower() in SENSITIVE_CONFIG_KEYS and item else redact_data(item, config)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_data(item, config) for item in value]
+    if isinstance(value, str):
+        return redact_text(value, config)
+    return value
+
+
+def get_exe_path():
+    return sys.executable if getattr(sys, "frozen", False) else str(Path(sys.argv[0]).resolve())
+
+
+def _startup_arguments(start_minimized=True):
+    if getattr(sys, "frozen", False):
+        args = [sys.executable]
+    else:
+        args = [sys.executable, str(Path(__file__).with_name("main.py"))]
+    if start_minimized:
+        args.append("--startup")
+    return args
+
+
+def is_startup_enabled():
+    path = Path(LAUNCH_AGENT_PATH)
+    if not path.exists():
+        return False
+    try:
+        with path.open("rb") as handle:
+            payload = plistlib.load(handle)
+        return payload.get("Label") == BUNDLE_IDENTIFIER and bool(payload.get("RunAtLoad"))
+    except (OSError, plistlib.InvalidFileException):
+        return False
+
+
+def set_startup(enable, start_minimized=True):
+    path = Path(LAUNCH_AGENT_PATH)
+    if not enable:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        return True
+    payload = {
+        "Label": BUNDLE_IDENTIFIER,
+        "ProgramArguments": _startup_arguments(start_minimized),
+        "RunAtLoad": True,
+        "ProcessType": "Interactive",
+        "StandardOutPath": LOG_PATH,
+        "StandardErrorPath": LOG_PATH,
+    }
+    _atomic_write(path, plistlib.dumps(payload, fmt=plistlib.FMT_XML))
+    return True

--- a/MacOS/dmg_settings.py
+++ b/MacOS/dmg_settings.py
@@ -1,0 +1,49 @@
+import os
+import plistlib
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    defines: dict[str, str] = {}
+
+application = os.path.abspath(defines["app"])  # noqa: F821 - injected by dmgbuild
+app_name = os.path.basename(application)
+
+
+def app_icon(app_path):
+    plist_path = os.path.join(app_path, "Contents", "Info.plist")
+    with open(plist_path, "rb") as plist_file:
+        bundle_info = plistlib.load(plist_file)
+    icon_name = bundle_info["CFBundleIconFile"]
+    if not os.path.splitext(icon_name)[1]:
+        icon_name += ".icns"
+    return os.path.join(app_path, "Contents", "Resources", icon_name)
+
+
+format = "UDZO"
+filesystem = "HFS+"
+files = [application]
+symlinks = {"Applications": "/Applications"}
+icon = app_icon(application)
+
+background = "builtin-arrow"
+window_rect = ((200, 200), (600, 400))
+default_view = "icon-view"
+show_status_bar = False
+show_tab_view = False
+show_toolbar = False
+show_pathbar = False
+show_sidebar = False
+show_icon_preview = True
+include_icon_view_settings = True
+arrange_by = None
+icon_size = 128
+text_size = 14
+icon_locations = {
+    app_name: (150, 190),
+    "Applications": (450, 190),
+}
+
+# Do not ask dmgbuild to toggle the signed app's Finder-extension bit. That
+# writes Finder metadata to the bundle after signing, and strict codesign
+# verification then rejects the mounted copy as containing detritus.

--- a/MacOS/dmg_settings.py
+++ b/MacOS/dmg_settings.py
@@ -1,3 +1,5 @@
+# MIT License - Copyright (c) 2026 eripum9
+
 import os
 import plistlib
 from typing import TYPE_CHECKING

--- a/MacOS/entitlements.plist
+++ b/MacOS/entitlements.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/MacOS/main.py
+++ b/MacOS/main.py
@@ -1,0 +1,199 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+"""macOS menu-bar application entrypoint."""
+
+from __future__ import annotations
+
+import signal
+import sys
+from pathlib import Path
+
+
+if __package__ in (None, ""):
+    PROJECT_DIR = Path(__file__).resolve().parent.parent
+    if str(PROJECT_DIR) not in sys.path:
+        sys.path.insert(0, str(PROJECT_DIR))
+    from MacOS import config
+    from MacOS.runtime import MacRuntime
+    from MacOS.single_instance import SingleInstance
+    from MacOS.ui import MacApplicationUI
+else:
+    from . import config
+    from .runtime import MacRuntime
+    from .single_instance import SingleInstance
+    from .ui import MacApplicationUI
+
+from PySide6.QtCore import QObject, QTimer, Signal
+from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import QApplication
+
+from Windows.qt_tray_ui import QtTrayController
+from Windows.structured_logging import StructuredLogTee, rotate_logs
+
+
+class _CommandBridge(QObject):
+    command_received = Signal(str)
+
+
+def _icon_path():
+    if getattr(sys, "frozen", False):
+        root = Path(getattr(sys, "_MEIPASS", Path(sys.executable).parent))
+        candidates = (root / "icon.png", root / "Resources" / "icon.png")
+    else:
+        candidates = (Path(__file__).resolve().parent.parent / "Windows" / "icon.png",)
+    return str(next((path for path in candidates if path.is_file()), candidates[0]))
+
+
+def _install_logging():
+    Path(config.CONFIG_DIR).mkdir(parents=True, exist_ok=True)
+    try:
+        rotate_logs(config.CONFIG_DIR, Path(config.LOG_PATH).name, 5)
+        rotate_logs(config.CONFIG_DIR, Path(config.EVENT_LOG_PATH).name, 5)
+    except OSError:
+        pass
+    original_out, original_err = sys.stdout, sys.stderr
+    redaction_config = config.load_config()
+    try:
+        sys.stdout = StructuredLogTee(
+            original_out,
+            config.LOG_PATH,
+            config.EVENT_LOG_PATH,
+            "stdout",
+            lambda value: config.redact_text(value, redaction_config),
+        )
+        sys.stderr = StructuredLogTee(
+            original_err,
+            config.LOG_PATH,
+            config.EVENT_LOG_PATH,
+            "stderr",
+            lambda value: config.redact_text(value, redaction_config),
+        )
+    except OSError:
+        sys.stdout, sys.stderr = original_out, original_err
+
+
+def _secondary_command(arguments):
+    if "--diagnostics" in arguments:
+        return "diagnostics"
+    return "settings"
+
+
+def main(argv=None):
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if "--version" in arguments:
+        print(config.APP_VERSION)
+        return 0
+
+    _install_logging()
+    app = QApplication.instance() or QApplication([sys.argv[0], *arguments])
+    app.setApplicationName(config.APP_DISPLAY_NAME)
+    app.setApplicationDisplayName(config.APP_DISPLAY_NAME)
+    app.setOrganizationName("eripum9")
+    app.setQuitOnLastWindowClosed(False)
+    icon_path = _icon_path()
+    if Path(icon_path).is_file():
+        app.setWindowIcon(QIcon(icon_path))
+
+    bridge = _CommandBridge()
+    instance = SingleInstance(lambda command: bridge.command_received.emit(command))
+    if not instance.acquire():
+        instance.notify(_secondary_command(arguments))
+        instance.close()
+        return 0
+
+    runtime = MacRuntime()
+    tray_holder = {"controller": None}
+    shutting_down = {"value": False}
+
+    def open_amazon():
+        import subprocess
+
+        return subprocess.Popen(
+            ["/usr/bin/open", "-a", "Amazon Music"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+
+    def shutdown():
+        if shutting_down["value"]:
+            return
+        shutting_down["value"] = True
+        print("[App] Shutting down.")
+        runtime.stop()
+        ui.shutdown()
+        instance.close()
+        tray = tray_holder.get("controller")
+        if tray:
+            tray.stop()
+        else:
+            app.quit()
+
+    ui = MacApplicationUI(
+        app,
+        runtime,
+        icon_path,
+        on_quit=shutdown,
+        on_open_amazon=open_amazon,
+    )
+
+    callbacks = dict(ui.callbacks)
+    callbacks.update(
+        {
+            "private": lambda: runtime.set_private_session(
+                not bool(config.load_config().get("privacy_private_session"))
+            ),
+            "game_mode": lambda: runtime.set_game_mode(
+                not bool(config.load_config().get("game_mode_enabled"))
+            ),
+            "toggle_rpc": lambda: runtime.set_rpc_enabled(not runtime.rpc_enabled),
+        }
+    )
+    tray = QtTrayController(icon_path, callbacks, runtime.snapshot())
+    tray_holder["controller"] = tray
+    runtime.add_listener(tray.update_state, emit_current=True)
+
+    def handle_command(command):
+        if command in {"activate", "settings"}:
+            ui.show_settings()
+        elif command == "diagnostics":
+            ui.show_diagnostics()
+        elif command == "quit":
+            shutdown()
+
+    bridge.command_received.connect(handle_command)
+
+    def signal_shutdown(_signal_number, _frame):
+        QTimer.singleShot(0, shutdown)
+
+    signal.signal(signal.SIGTERM, signal_shutdown)
+    signal.signal(signal.SIGINT, signal_shutdown)
+    app.aboutToQuit.connect(lambda: instance.close())
+
+    runtime.start()
+    saved = config.load_config()
+    first_run = not saved.get("intro_seen") or not saved.get("setup_wizard_seen")
+    if "--diagnostics" in arguments:
+        QTimer.singleShot(0, ui.show_diagnostics)
+    elif "--settings" in arguments or first_run or not saved.get("start_minimized", True):
+        QTimer.singleShot(0, ui.show_settings)
+
+    if saved.get("automatic_update_checks", True):
+        def automatic_update_check():
+            from MacOS.updater import check_for_update
+
+            def done(update):
+                if getattr(update, "available", False):
+                    ui.check_updates()
+
+            ui.run_background(check_for_update, done, lambda _error: None)
+
+        QTimer.singleShot(5000, automatic_update_check)
+
+    print(f"[App] {config.APP_DISPLAY_NAME} {config.APP_VERSION} started.")
+    return tray.run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/MacOS/media_reader.py
+++ b/MacOS/media_reader.py
@@ -1,0 +1,115 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+import json
+import math
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+AMAZON_MUSIC_BUNDLE_ID = "com.amazon.music"
+MAX_PROBE_OUTPUT_BYTES = 64 * 1024
+PROBE_PATH = Path(__file__).with_name("amazon_music_now_playing.js")
+
+
+def _text(value, limit=2048):
+    return str(value or "").strip()[:limit]
+
+
+def _seconds(value):
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, number) if math.isfinite(number) else 0.0
+
+
+def _position(value, duration):
+    try:
+        position = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(position):
+        return None
+    position = max(0.0, position)
+    if duration > 0:
+        position = min(position, duration)
+    return position
+
+
+def _https_artwork_url(value):
+    url = _text(value, 4096)
+    if not url:
+        return ""
+    try:
+        parsed = urlparse(url)
+        port = parsed.port
+    except ValueError:
+        return ""
+    if (
+        parsed.scheme.lower() != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or port not in (None, 443)
+    ):
+        return ""
+    return url
+
+
+def parse_probe_payload(payload):
+    if not isinstance(payload, Mapping):
+        return None
+    if payload.get("status") != "found":
+        return None
+    if _text(payload.get("bundle_identifier"), 256) != AMAZON_MUSIC_BUNDLE_ID:
+        return None
+
+    title = _text(payload.get("title"), 512)
+    artist = _text(payload.get("artist"), 512)
+    album = _text(payload.get("album"), 512)
+    if not title:
+        return None
+
+    duration = _seconds(payload.get("duration"))
+    position = _position(payload.get("position"), duration)
+    playback_rate = _seconds(payload.get("playback_rate"))
+    status = "playing" if playback_rate > 0 else "paused"
+    art_url = _https_artwork_url(payload.get("artwork_url"))
+
+    return {
+        "title": title,
+        "artist": artist,
+        "album": album,
+        "status": status,
+        "position": position,
+        "duration": duration,
+        "art_url": art_url,
+        "source": "macos_now_playing",
+    }
+
+
+def get_track_sync(timeout=4.0, runner=subprocess.run, platform=None):
+    if (platform or sys.platform) != "darwin":
+        return None
+    try:
+        completed = runner(
+            ["/usr/bin/osascript", "-l", "JavaScript", str(PROBE_PATH)],
+            capture_output=True,
+            text=True,
+            timeout=max(0.1, float(timeout)),
+        )
+    except (OSError, subprocess.SubprocessError, TypeError, ValueError):
+        return None
+    if completed.returncode != 0:
+        return None
+    output = completed.stdout or ""
+    if len(output.encode("utf-8", errors="replace")) > MAX_PROBE_OUTPUT_BYTES:
+        return None
+    try:
+        payload = json.loads(output)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return parse_probe_payload(payload)

--- a/MacOS/requirements-build.txt
+++ b/MacOS/requirements-build.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+PyInstaller==6.21.0
+dmgbuild==1.6.7

--- a/MacOS/requirements.txt
+++ b/MacOS/requirements.txt
@@ -1,0 +1,6 @@
+pypresence==4.6.2
+requests==2.34.2
+Pillow==12.3.0
+PySide6-Essentials==6.9.3
+pylast==7.1.0
+liblistenbrainz==0.7.0

--- a/MacOS/runtime.py
+++ b/MacOS/runtime.py
@@ -1,0 +1,883 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+"""Cross-platform feature core composed with macOS metadata backends."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from Shared.playback import (
+    apply_track_mapping,
+    configured_game_mode_processes,
+    find_custom_album_art,
+    game_mode_matches_processes,
+    nonnegative_number,
+    normalise_track,
+    privacy_reason,
+    remembered_track_mapping,
+    remembered_track_mapping_key,
+    same_track_field,
+    scrobble_eligible,
+)
+
+from . import amazon_devtools, config, media_reader
+
+
+POLL_SECONDS = 2.0
+PAUSE_ICON_URL = (
+    "https://raw.githubusercontent.com/eripum9/"
+    "Amazon-Music-Discord-RPC/master/Images/pause_icon.png"
+)
+
+
+def _shared_discord_factory(client_id):
+    from Windows.discord_rpc import DiscordRPC
+
+    return DiscordRPC(client_id)
+
+
+def _shared_lastfm_factory(api_key, api_secret, session_key, privacy_enabled=False):
+    from Windows.lastfm import LastFMScrobbler
+
+    return LastFMScrobbler(api_key, api_secret, session_key, privacy_enabled)
+
+
+def _shared_listenbrainz_factory(token, privacy_enabled=False):
+    from Windows.listenbrainz_scrobbler import ListenBrainzScrobbler
+
+    return ListenBrainzScrobbler(token, privacy_enabled)
+
+
+def _shared_art_lookup(title, artist, *, deezer_enabled=True, itunes_enabled=True):
+    from Windows.album_art import get_album_art
+
+    return get_album_art(
+        title,
+        artist,
+        deezer_enabled=deezer_enabled,
+        itunes_enabled=itunes_enabled,
+    )
+
+
+def _running_process_names():
+    try:
+        completed = subprocess.run(
+            ["/bin/ps", "-axo", "comm="],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    if completed.returncode != 0:
+        return set()
+    names = set()
+    for line in completed.stdout.splitlines():
+        name = os.path.basename(line.strip()).casefold()
+        if name:
+            names.add(name)
+            names.add(os.path.splitext(name)[0])
+    return names
+
+
+def _record_network_event(service, operation, status, detail=""):
+    try:
+        from Windows.network_audit import record_network_event
+
+        record_network_event(service, operation, status, detail, config.CONFIG_DIR)
+    except Exception:
+        pass
+
+
+@dataclass(slots=True)
+class RuntimeDependencies:
+    discord_factory: Callable = _shared_discord_factory
+    lastfm_factory: Callable = _shared_lastfm_factory
+    listenbrainz_factory: Callable = _shared_listenbrainz_factory
+    art_lookup: Callable = _shared_art_lookup
+    devtools_track: Callable = amazon_devtools.get_devtools_track_sync
+    devtools_launch: Callable = amazon_devtools.launch_amazon_music_devtools
+    devtools_restart: Callable = amazon_devtools.restart_amazon_music_devtools
+    devtools_disable: Callable = amazon_devtools.disable_amazon_music_devtools
+    devtools_status: Callable = amazon_devtools.get_devtools_status
+    amazon_running: Callable = amazon_devtools.amazon_music_is_running
+    now_playing_track: Callable = media_reader.get_track_sync
+    process_names: Callable = _running_process_names
+    network_event: Callable = _record_network_event
+    clock: Callable = time.time
+
+
+def _number(value, default=0.0):
+    return nonnegative_number(value, default)
+
+
+_normalise_track = normalise_track
+_privacy_reason = privacy_reason
+_mapping = apply_track_mapping
+
+
+def _configured_processes(value):
+    return configured_game_mode_processes(value)
+
+
+def _custom_art(settings, album):
+    custom = find_custom_album_art(settings, album)
+    if not custom:
+        return None
+    return custom["art_url"], custom.get("album") or album
+
+
+def _privacy_safe_devtools_state(state):
+    if not isinstance(state, dict):
+        return {}
+    allowed = ("enabled", "status", "detail", "source", "port", "method", "owner")
+    return {key: state[key] for key in allowed if key in state}
+
+
+class MacRuntime:
+    """Owns metadata polling, presence, privacy, artwork and scrobbling."""
+
+    def __init__(self, dependencies=None, settings_loader=config.load_config):
+        self.dependencies = dependencies or RuntimeDependencies()
+        self._settings_loader = settings_loader
+        self._settings = settings_loader()
+        self._config_mtime = self._configuration_mtime()
+        self._listeners = []
+        self._lock = threading.RLock()
+        self._stop = threading.Event()
+        self._thread = None
+        self._rpc_enabled = True
+        self._rpc = None
+        self._last_client_id = ""
+        self._last_service_fingerprint = None
+        self._lastfm = None
+        self._listenbrainz = None
+        self._track_key = ""
+        self._session_track_mappings = {}
+        self._track_started_at = None
+        self._scrobble_position_baseline = 0.0
+        self._scrobbling_was_blocked = False
+        self._scrobbled = False
+        self._art_key = ""
+        self._art_url = ""
+        self._album = ""
+        self._deezer_link = ""
+        self._presence_visible = False
+        self._last_error = ""
+        self._snapshot = self._empty_snapshot()
+
+    def _empty_snapshot(self):
+        return {
+            "updated_at": self.dependencies.clock(),
+            "app_version": config.APP_VERSION,
+            "rpc_status": "running" if self._rpc_enabled else "stopped",
+            "rpc": "on" if self._rpc_enabled else "off",
+            "discord_status": "waiting",
+            "discord": "Waiting",
+            "track": None,
+            "title": "",
+            "artist": "",
+            "album": "",
+            "time": "",
+            "presence_visible": False,
+            "source": "Waiting",
+            "source_detail": "Waiting for Amazon Music",
+            "amazon_devtools": {"status": "waiting", "detail": "Not checked yet"},
+            "devtools_status": "waiting",
+            "scrobbling": {"lastfm": "disabled", "listenbrainz": "disabled"},
+            "privacy": {"private_session": False, "hidden": False, "reason": ""},
+            "private": False,
+            "game_mode": "off",
+            "correction_suggested": False,
+            "last_error": "",
+        }
+
+    def add_listener(self, callback, emit_current=True):
+        with self._lock:
+            if callback not in self._listeners:
+                self._listeners.append(callback)
+            snapshot = dict(self._snapshot)
+        if emit_current:
+            callback(snapshot)
+
+    def remove_listener(self, callback):
+        with self._lock:
+            if callback in self._listeners:
+                self._listeners.remove(callback)
+
+    def snapshot(self):
+        with self._lock:
+            return json.loads(json.dumps(self._snapshot))
+
+    @property
+    def running(self):
+        return bool(self._thread and self._thread.is_alive())
+
+    @property
+    def rpc_enabled(self):
+        return self._rpc_enabled
+
+    def start(self):
+        if self.running:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._loop, name="macos-rpc-runtime", daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        if self._thread and self._thread is not threading.current_thread():
+            self._thread.join(timeout=8)
+        self._shutdown_services()
+        self._rpc_enabled = False
+        self._publish(rpc_status="stopped", rpc="off", presence_visible=False)
+
+    def set_rpc_enabled(self, enabled):
+        self._rpc_enabled = bool(enabled)
+        if not enabled:
+            self._clear_presence()
+        self._publish(
+            rpc_status="running" if enabled else "stopped",
+            rpc="on" if enabled else "off",
+        )
+
+    def reload_config(self, settings=None):
+        self._settings = dict(settings or self._settings_loader())
+        self._config_mtime = self._configuration_mtime()
+        self._ensure_services(force=True)
+        return self._settings
+
+    def _configuration_mtime(self):
+        try:
+            return os.stat(config.CONFIG_PATH).st_mtime_ns
+        except OSError:
+            return 0
+
+    def _reload_if_changed(self):
+        modified = self._configuration_mtime()
+        if modified == self._config_mtime:
+            return
+        loaded = self._settings_loader()
+        self._config_mtime = modified
+        if loaded.get(config.CONFIG_REVISION_KEY) != self._settings.get(config.CONFIG_REVISION_KEY):
+            self._settings = loaded
+            self._ensure_services(force=True)
+
+    def set_private_session(self, enabled):
+        settings = config.update_config_fields({"privacy_private_session": bool(enabled)})
+        self.reload_config(settings)
+        if enabled:
+            if settings.get("privacy_disable_scrobbling", True):
+                # Never let listening time accumulated before or during a
+                # private session count after the session is disabled.
+                self._scrobbling_was_blocked = True
+                self._track_started_at = None
+                self._scrobble_position_baseline = 0.0
+                self._scrobbled = False
+            self._clear_presence()
+            current = self._snapshot.get("track") or {}
+            hidden = {
+                "title": "Hidden by privacy controls",
+                "artist": "",
+                "album": "",
+                "status": current.get("status", ""),
+                "position": current.get("position"),
+                "duration": current.get("duration", 0),
+                "source": current.get("source", ""),
+            }
+            self._publish(
+                track=hidden,
+                title=hidden["title"],
+                artist="",
+                album="",
+                album_art_url="",
+                track_link="",
+                raw_track={},
+                amazon_devtools=_privacy_safe_devtools_state(
+                    self._snapshot.get("amazon_devtools")
+                ),
+                presence_visible=False,
+                private=True,
+                correction_suggested=False,
+                privacy={
+                    "private_session": True,
+                    "hidden": True,
+                    "reason": "Private session enabled",
+                },
+            )
+        else:
+            self._publish(
+                private=False,
+                privacy={"private_session": False, "hidden": False, "reason": ""},
+            )
+        return settings
+
+    def set_game_mode(self, enabled):
+        settings = config.update_config_fields({"game_mode_enabled": bool(enabled)})
+        self.reload_config(settings)
+        self._publish(game_mode="on" if enabled else "off")
+        return settings
+
+    def game_mode_active(self):
+        if self._settings.get("game_mode_enabled"):
+            return True
+        configured = _configured_processes(self._settings.get("game_mode_processes"))
+        if not configured:
+            return False
+        return game_mode_matches_processes(configured, self.dependencies.process_names())
+
+    def remember_correction(self, raw_title, raw_artist, corrected):
+        key = remembered_track_mapping_key(raw_title, raw_artist)
+
+        def transform(fields):
+            mappings = dict(fields.get("track_mappings") or {})
+            mappings[key] = {
+                field: corrected.get(field, "")
+                for field in ("title", "artist", "album", "art_url", "track_link", "duration")
+            }
+            return {"track_mappings": mappings}
+
+        settings = config.mutate_config_fields({"track_mappings"}, transform)
+        with self._lock:
+            self._session_track_mappings.pop(key, None)
+            self._track_key = ""
+            self._art_key = ""
+        self.reload_config(settings)
+        return settings
+
+    def apply_session_correction(self, raw_title, raw_artist, corrected):
+        """Apply a correction until the app exits without writing settings."""
+
+        key = remembered_track_mapping_key(raw_title, raw_artist)
+        mapping = {
+            field: corrected.get(field, "")
+            for field in ("title", "artist", "album", "art_url", "track_link", "duration")
+        }
+        with self._lock:
+            self._session_track_mappings[key] = mapping
+            self._track_key = ""
+            self._art_key = ""
+        return mapping
+
+    def apply_correction(self, raw_title, raw_artist, corrected, *, remember=False):
+        if remember:
+            return self.remember_correction(raw_title, raw_artist, corrected)
+        return self.apply_session_correction(raw_title, raw_artist, corrected)
+
+    def launch_enhanced_metadata(self, restart_if_needed=False):
+        result = self.dependencies.devtools_launch()
+        if result.get("restart_required") and restart_if_needed:
+            result = self.dependencies.devtools_restart()
+        self._publish(
+            amazon_devtools={
+                "enabled": True,
+                "status": result.get("status", "error"),
+                "detail": result.get("error") or "Enhanced metadata is ready",
+                "port": result.get("port"),
+            },
+            devtools_status=result.get("status", "error"),
+        )
+        return result
+
+    def disable_enhanced_metadata(self, *, relaunch=True):
+        """Explicitly remove the listener and reopen Amazon Music normally."""
+
+        result = self.dependencies.devtools_disable(relaunch=relaunch)
+        if result.get("ok"):
+            settings = config.update_config_fields(
+                {
+                    "amazon_devtools_enabled": False,
+                    "amazon_devtools_auto_launch": False,
+                }
+            )
+            self.reload_config(settings)
+        self._publish(
+            amazon_devtools={
+                "enabled": False,
+                "status": result.get("status", "error"),
+                "detail": (
+                    result.get("error")
+                    or "Amazon Music reopened normally without a DevTools listener"
+                ),
+            },
+            devtools_status=result.get("status", "error"),
+        )
+        return result
+
+    def _loop(self):
+        while not self._stop.is_set():
+            try:
+                self.tick()
+                self._last_error = ""
+            except Exception as error:
+                self._last_error = f"{type(error).__name__}: {error}"
+                self._publish(last_error=self._last_error)
+            self._stop.wait(POLL_SECONDS)
+
+    def _client_id(self):
+        if self._settings.get("use_custom_client_id") and self._settings.get("discord_client_id"):
+            return str(self._settings["discord_client_id"])
+        return config.DEFAULT_CLIENT_ID
+
+    def _ensure_services(self, force=False):
+        client_id = self._client_id()
+        if force or client_id != self._last_client_id:
+            if self._rpc:
+                try:
+                    self._rpc.shutdown()
+                except Exception:
+                    pass
+            self._rpc = self.dependencies.discord_factory(client_id)
+            self._last_client_id = client_id
+
+        fingerprint = (
+            bool(self._settings.get("lastfm_enabled")),
+            self._settings.get("lastfm_api_key"),
+            self._settings.get("lastfm_api_secret"),
+            self._settings.get("lastfm_session_key"),
+            bool(self._settings.get("listenbrainz_enabled")),
+            self._settings.get("listenbrainz_token"),
+            bool(self._settings.get("privacy_private_session")),
+            bool(self._settings.get("privacy_disable_scrobbling", True)),
+        )
+        if not force and fingerprint == self._last_service_fingerprint:
+            return
+        for service in (self._lastfm, self._listenbrainz):
+            if service and hasattr(service, "close"):
+                try:
+                    service.close()
+                except Exception:
+                    pass
+        self._lastfm = None
+        self._listenbrainz = None
+        privacy = bool(
+            self._settings.get("privacy_private_session")
+            and self._settings.get("privacy_disable_scrobbling", True)
+        )
+        if self._settings.get("lastfm_enabled") and self._settings.get("lastfm_session_key"):
+            try:
+                self._lastfm = self.dependencies.lastfm_factory(
+                    self._settings.get("lastfm_api_key"),
+                    self._settings.get("lastfm_api_secret"),
+                    self._settings.get("lastfm_session_key"),
+                    privacy,
+                )
+            except Exception as error:
+                self._last_error = f"Last.fm: {error}"
+        if self._settings.get("listenbrainz_enabled") and self._settings.get("listenbrainz_token"):
+            try:
+                self._listenbrainz = self.dependencies.listenbrainz_factory(
+                    self._settings.get("listenbrainz_token"), privacy
+                )
+            except Exception as error:
+                self._last_error = f"ListenBrainz: {error}"
+        self._last_service_fingerprint = fingerprint
+
+    def _shutdown_services(self):
+        self._clear_presence()
+        for service in (self._lastfm, self._listenbrainz):
+            if service and hasattr(service, "close"):
+                try:
+                    service.close()
+                except Exception:
+                    pass
+        self._lastfm = None
+        self._listenbrainz = None
+        if self._rpc:
+            try:
+                self._rpc.shutdown()
+            except Exception:
+                pass
+        self._rpc = None
+
+    def _read_track(self):
+        devtools_state = {
+            "enabled": bool(self._settings.get("amazon_devtools_enabled")),
+            "status": "off",
+            "detail": "Enhanced metadata is disabled",
+            "source": "amazon_devtools",
+        }
+        track = None
+        if self._settings.get("amazon_devtools_enabled"):
+            raw = self.dependencies.devtools_track(
+                self._settings.get("amazon_music_link_region", "com")
+            )
+            devtools_state = {"enabled": True, **(raw if isinstance(raw, dict) else {})}
+            track = _normalise_track(raw, "amazon_devtools") if raw and raw.get("status") == "found" else None
+            if not track and self._settings.get("amazon_devtools_auto_launch"):
+                if not self.dependencies.amazon_running():
+                    result = self.dependencies.devtools_launch()
+                    devtools_state = {
+                        "enabled": True,
+                        "status": result.get("status", "launching"),
+                        "detail": result.get("error") or "Launching Amazon Music for enhanced metadata",
+                        "port": result.get("port"),
+                    }
+                else:
+                    devtools_state = {
+                        "enabled": True,
+                        "status": "restart_required",
+                        "detail": "Amazon Music needs your approval for a one-time DevTools restart",
+                    }
+        if not track:
+            track = _normalise_track(self.dependencies.now_playing_track(), "macos_now_playing")
+        return track, devtools_state
+
+    def _resolve_art(self, track):
+        key = f"{track['title']}|{track['artist']}"
+        if key == self._art_key:
+            return
+        self._art_key = key
+        self._art_url = track.get("art_url", "")
+        self._album = track.get("album", "")
+        self._deezer_link = ""
+        if not self._art_url:
+            self.dependencies.network_event("artwork", "lookup", "started", "new track")
+            try:
+                art, album, link, duration = self.dependencies.art_lookup(
+                    track["title"],
+                    track["artist"],
+                    deezer_enabled=self._settings.get("deezer_lookup_enabled", True),
+                    itunes_enabled=self._settings.get("itunes_lookup_enabled", True),
+                )
+                self._art_url = art or ""
+                self._album = album or self._album
+                self._deezer_link = link or ""
+                if duration and not track.get("duration"):
+                    track["duration"] = _number(duration)
+                self.dependencies.network_event("artwork", "lookup", "success", "completed")
+            except Exception as error:
+                self.dependencies.network_event("artwork", "lookup", "error", type(error).__name__)
+        custom = _custom_art(self._settings, self._album or track.get("album"))
+        if custom:
+            self._art_url, self._album = custom
+
+    def _buttons(self, track):
+        if not self._settings.get("song_link_enabled"):
+            return None
+        provider = self._settings.get("song_link_provider", "amazon")
+        if provider == "deezer" and self._deezer_link:
+            return [{"label": "Listen on Deezer", "url": self._deezer_link}]
+        link = track.get("track_link") or amazon_devtools.amazon_music_search_link(
+            track.get("title"),
+            track.get("artist"),
+            self._settings.get("amazon_music_link_region"),
+        )
+        return [{"label": "Listen on Amazon Music", "url": link}] if link else None
+
+    def _scrobbling_status(self):
+        if self._settings.get("lastfm_enabled"):
+            lastfm = "active" if self._lastfm else "not_authenticated"
+        else:
+            lastfm = "disabled"
+        if self._settings.get("listenbrainz_enabled"):
+            listenbrainz = "active" if self._listenbrainz else "missing_token"
+        else:
+            listenbrainz = "disabled"
+        return {"lastfm": lastfm, "listenbrainz": listenbrainz}
+
+    def _new_track(
+        self,
+        track,
+        allow_scrobbling=True,
+        start_scrobble_fresh=False,
+        allow_artwork=True,
+    ):
+        self._track_key = f"{track['title']}|{track['artist']}"
+        position = track.get("position")
+        if start_scrobble_fresh:
+            self._track_started_at = self.dependencies.clock()
+            self._scrobble_position_baseline = _number(position)
+        else:
+            self._track_started_at = (
+                self.dependencies.clock() - position
+                if position is not None
+                else self.dependencies.clock()
+            )
+            self._scrobble_position_baseline = 0.0
+        self._scrobbled = False
+        if allow_artwork:
+            self._resolve_art(track)
+        else:
+            # Preserve metadata already supplied locally, but never send a
+            # hidden title/artist to an artwork provider.
+            self._art_key = ""
+            self._art_url = track.get("art_url", "")
+            self._album = track.get("album", "")
+            self._deezer_link = ""
+        duration = track.get("duration") or 0
+        for service in (self._lastfm, self._listenbrainz) if allow_scrobbling else ():
+            if service:
+                try:
+                    service.update_now_playing(
+                        track["title"], track["artist"], self._album, duration
+                    )
+                except Exception:
+                    pass
+
+    def _try_scrobble(self, track):
+        if self._scrobbled or not self._track_started_at:
+            return
+        if self._settings.get("privacy_private_session") and self._settings.get(
+            "privacy_disable_scrobbling", True
+        ):
+            return
+        elapsed = (
+            max(
+                0.0,
+                _number(track.get("position")) - self._scrobble_position_baseline,
+            )
+            if track.get("position") is not None
+            else self.dependencies.clock() - self._track_started_at
+        )
+        duration = _number(track.get("duration"))
+        if not scrobble_eligible(elapsed, duration):
+            return
+        for service in (self._lastfm, self._listenbrainz):
+            if service:
+                try:
+                    service.scrobble(
+                        track["title"],
+                        track["artist"],
+                        int(self._track_started_at),
+                        self._album,
+                        duration,
+                    )
+                except Exception:
+                    pass
+        self._scrobbled = True
+
+    def _clear_presence(self):
+        if self._rpc and self._presence_visible:
+            try:
+                self._rpc.clear()
+            except Exception:
+                pass
+        self._presence_visible = False
+
+    def tick(self):
+        self._reload_if_changed()
+        self._ensure_services()
+
+        if not self._rpc_enabled:
+            self._clear_presence()
+            self._publish(
+                rpc_status="stopped",
+                rpc="off",
+                discord_status="disconnected",
+                discord="Disconnected",
+                presence_visible=False,
+                correction_suggested=False,
+            )
+            return self.snapshot()
+
+        track, devtools = self._read_track()
+        if not track:
+            self._clear_presence()
+            self._track_key = ""
+            self._track_started_at = None
+            self._scrobble_position_baseline = 0.0
+            self._scrobbled = False
+            if not self._settings.get("privacy_private_session"):
+                self._scrobbling_was_blocked = False
+            self._art_key = ""
+            self._art_url = ""
+            self._album = ""
+            self._deezer_link = ""
+            self._publish(
+                rpc_status="running",
+                rpc="on",
+                track=None,
+                title="",
+                artist="",
+                album="",
+                raw_track={},
+                album_art_url="",
+                track_link="",
+                time="",
+                source="Waiting",
+                source_detail=devtools.get("detail") or "Waiting for Amazon Music",
+                amazon_devtools=devtools,
+                devtools_status=devtools.get("status", "waiting"),
+                presence_visible=False,
+                discord_status="connected" if self._rpc and self._rpc.connected else "waiting",
+                discord="Connected" if self._rpc and self._rpc.connected else "Waiting",
+                scrobbling=self._scrobbling_status(),
+                private=bool(self._settings.get("privacy_private_session")),
+                game_mode="on" if self.game_mode_active() else "off",
+                correction_suggested=False,
+                last_error=self._last_error,
+            )
+            return self.snapshot()
+
+        raw_title, raw_artist = track["title"], track["artist"]
+        with self._lock:
+            session_mappings = dict(self._session_track_mappings)
+        session_mapping = remembered_track_mapping(
+            session_mappings, raw_title, raw_artist
+        )
+        saved_mapping = session_mapping or remembered_track_mapping(
+            self._settings, raw_title, raw_artist
+        )
+        track = _mapping(
+            session_mappings if session_mapping else self._settings,
+            track,
+        )
+        privacy_reason = _privacy_reason(self._settings, track)
+        correction_suggested = bool(
+            not privacy_reason
+            and not saved_mapping
+            and same_track_field(raw_title, raw_artist)
+            and not self.game_mode_active()
+        )
+        allow_scrobbling = not privacy_reason or not self._settings.get(
+            "privacy_disable_scrobbling", True
+        )
+        track_key = f"{track['title']}|{track['artist']}"
+        scrobbling_blocked = bool(privacy_reason and not allow_scrobbling)
+        resume_after_privacy = bool(
+            not scrobbling_blocked and self._scrobbling_was_blocked
+        )
+        if scrobbling_blocked:
+            self._scrobbling_was_blocked = True
+            self._track_started_at = None
+            self._scrobble_position_baseline = 0.0
+            self._scrobbled = False
+        elif track_key != self._track_key or resume_after_privacy:
+            self._scrobbling_was_blocked = False
+            self._new_track(
+                track,
+                allow_scrobbling=allow_scrobbling,
+                start_scrobble_fresh=resume_after_privacy,
+                allow_artwork=not privacy_reason,
+            )
+        elif track.get("album") and not self._album:
+            self._album = track["album"]
+        if not privacy_reason and self._art_key != track_key:
+            self._resolve_art(track)
+
+        paused = track["status"] == "paused"
+        should_show = not privacy_reason and (not paused or self._settings.get("show_paused", True))
+        if should_show:
+            start_ts = None
+            duration = track.get("duration") or 0
+            if track.get("position") is not None:
+                start_ts = int(self.dependencies.clock() - track["position"])
+            elif not paused:
+                start_ts = int(self._track_started_at or self.dependencies.clock())
+            self._rpc.update(
+                title=track["title"],
+                artist=track["artist"],
+                album_art_url=self._art_url,
+                album_name=self._album,
+                start_ts=start_ts,
+                duration=duration,
+                buttons=self._buttons(track),
+                small_image=PAUSE_ICON_URL if paused else None,
+                small_text="Paused" if paused else None,
+                status_display=self._settings.get("discord_status_display", "artist"),
+            )
+            self._presence_visible = bool(self._rpc.connected)
+        else:
+            self._clear_presence()
+
+        if not paused and allow_scrobbling:
+            self._try_scrobble(track)
+
+        position = track.get("position")
+        duration = track.get("duration") or 0
+        time_label = ""
+        if position is not None:
+            def stamp(seconds):
+                seconds = int(max(0, seconds))
+                return f"{seconds // 60}:{seconds % 60:02d}"
+
+            time_label = stamp(position)
+            if duration:
+                time_label += f" / {stamp(duration)}"
+        public_track = dict(track)
+        public_track["album"] = self._album or track.get("album", "")
+        if privacy_reason:
+            public_track = {
+                "title": "Hidden by privacy controls",
+                "artist": "",
+                "album": "",
+                "status": track["status"],
+                "position": track.get("position"),
+                "duration": track.get("duration"),
+                "source": track.get("source"),
+            }
+        source_label = "Amazon metadata" if track["source"] == "amazon_devtools" else "macOS fallback"
+        self._publish(
+            rpc_status="running",
+            rpc="on",
+            discord_status="connected" if self._rpc.connected else "retrying",
+            discord="Connected" if self._rpc.connected else "Retrying",
+            track=public_track,
+            raw_track=(
+                {}
+                if privacy_reason
+                else {"title": raw_title, "artist": raw_artist}
+            ),
+            title=public_track["title"],
+            artist=public_track.get("artist", ""),
+            album=public_track.get("album", ""),
+            time=time_label,
+            source="Paused" if paused else source_label,
+            source_detail=devtools.get("detail") or source_label,
+            amazon_devtools=(
+                _privacy_safe_devtools_state(devtools)
+                if privacy_reason
+                else devtools
+            ),
+            devtools_status=devtools.get("status", "waiting"),
+            presence_visible=self._presence_visible,
+            album_art_url=self._art_url if not privacy_reason else "",
+            track_link=track.get("track_link", "") if not privacy_reason else "",
+            scrobbling=self._scrobbling_status(),
+            privacy={
+                "private_session": bool(self._settings.get("privacy_private_session")),
+                "hidden": bool(privacy_reason),
+                "reason": privacy_reason,
+            },
+            private=bool(self._settings.get("privacy_private_session")),
+            game_mode="on" if self.game_mode_active() else "off",
+            correction_suggested=correction_suggested,
+            last_error=self._last_error,
+        )
+        return self.snapshot()
+
+    def _publish(self, **changes):
+        with self._lock:
+            self._snapshot.update(changes)
+            self._snapshot["updated_at"] = self.dependencies.clock()
+            snapshot = json.loads(json.dumps(self._snapshot, default=str))
+            listeners = list(self._listeners)
+        self._write_diagnostics(snapshot)
+        for callback in listeners:
+            try:
+                callback(snapshot)
+            except Exception:
+                pass
+
+    def _write_diagnostics(self, snapshot):
+        path = Path(config.DIAGNOSTICS_PATH)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            temporary = path.with_suffix(".tmp")
+            temporary.write_text(
+                json.dumps(config.redact_data(snapshot, self._settings), indent=2),
+                encoding="utf-8",
+            )
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, path)
+        except OSError:
+            pass

--- a/MacOS/scripts/build_app.sh
+++ b/MacOS/scripts/build_app.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+PROJECT_DIR="$(cd -- "${MACOS_DIR}/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-${PROJECT_DIR}/.venv/bin/python}"
+SPEC_PATH="${MACOS_DIR}/AmazonMusicRPC.spec"
+DIST_DIR="${MACOS_DIR}/dist"
+WORK_DIR="${MACOS_DIR}/build/pyinstaller"
+APP_PATH="${DIST_DIR}/Amazon Music RPC.app"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "The macOS application bundle must be built on macOS." >&2
+    exit 1
+fi
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+    echo "Python was not found at ${PYTHON_BIN}. Set PYTHON_BIN to a Python 3.12 executable." >&2
+    exit 1
+fi
+
+if [[ ! -f "${MACOS_DIR}/main.py" ]]; then
+    echo "Application entrypoint is missing: ${MACOS_DIR}/main.py" >&2
+    exit 1
+fi
+
+if ! "${PYTHON_BIN}" -c 'import PyInstaller' >/dev/null 2>&1; then
+    echo "PyInstaller is not installed. Run:" >&2
+    echo "  ${PYTHON_BIN} -m pip install -r ${MACOS_DIR}/requirements-build.txt" >&2
+    exit 1
+fi
+
+if [[ -z "${APP_VERSION:-}" ]]; then
+    APP_VERSION="$(git -C "${PROJECT_DIR}" describe --tags --abbrev=0 2>/dev/null | /usr/bin/sed 's/^v//' || true)"
+    APP_VERSION="${APP_VERSION:-0.1.0}"
+fi
+if [[ -z "${APP_BUILD:-}" ]]; then
+    APP_BUILD="$(git -C "${PROJECT_DIR}" rev-list --count HEAD 2>/dev/null || true)"
+    APP_BUILD="${APP_BUILD:-1}"
+fi
+
+if [[ ! "${APP_VERSION}" =~ ^[0-9]+([.][0-9]+){0,2}$ ]]; then
+    echo "APP_VERSION must contain one to three dot-separated integers; got ${APP_VERSION}." >&2
+    exit 1
+fi
+if [[ ! "${APP_BUILD}" =~ ^[0-9]+([.][0-9]+){0,2}$ ]]; then
+    echo "APP_BUILD must contain one to three dot-separated integers; got ${APP_BUILD}." >&2
+    exit 1
+fi
+
+export APP_VERSION APP_BUILD
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-12.0}"
+export PYINSTALLER_STRICT_BUNDLE_CODESIGN_ERROR=1
+
+"${SCRIPT_DIR}/generate_icon.sh"
+/bin/mkdir -p -- "${DIST_DIR}" "${WORK_DIR}"
+
+echo "Building Amazon Music RPC ${APP_VERSION} (${APP_BUILD})"
+echo "Python architecture: $("${PYTHON_BIN}" -c 'import platform; print(platform.machine())')"
+if [[ -n "${MACOS_CODESIGN_IDENTITY:-}" ]]; then
+    echo "Signing identity: ${MACOS_CODESIGN_IDENTITY}"
+else
+    echo "Signing identity: ad hoc (prototype only)"
+fi
+
+"${PYTHON_BIN}" -m PyInstaller \
+    --noconfirm \
+    --clean \
+    --workpath "${WORK_DIR}" \
+    --distpath "${DIST_DIR}" \
+    "${SPEC_PATH}"
+
+/usr/bin/plutil -lint "${APP_PATH}/Contents/Info.plist"
+/usr/bin/codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
+
+BUNDLE_ID="$(/usr/bin/plutil -extract CFBundleIdentifier raw "${APP_PATH}/Contents/Info.plist")"
+BUNDLE_VERSION="$(/usr/bin/plutil -extract CFBundleShortVersionString raw "${APP_PATH}/Contents/Info.plist")"
+BUNDLE_BUILD="$(/usr/bin/plutil -extract CFBundleVersion raw "${APP_PATH}/Contents/Info.plist")"
+BUNDLE_AGENT="$(/usr/bin/plutil -extract LSUIElement raw "${APP_PATH}/Contents/Info.plist")"
+if [[ "${BUNDLE_ID}" != "io.github.eripum9.amazon-music-rpc" ]]; then
+    echo "Unexpected bundle identifier: ${BUNDLE_ID}" >&2
+    exit 1
+fi
+if [[ "${BUNDLE_VERSION}" != "${APP_VERSION}" || "${BUNDLE_BUILD}" != "${APP_BUILD}" ]]; then
+    echo "Built bundle version does not match APP_VERSION/APP_BUILD." >&2
+    exit 1
+fi
+if [[ "${BUNDLE_AGENT}" != "true" ]]; then
+    echo "LSUIElement must remain enabled for the menu-bar application." >&2
+    exit 1
+fi
+if [[ -n "${MACOS_CODESIGN_IDENTITY:-}" ]]; then
+    SIGNATURE_DETAILS="$(/usr/bin/codesign -dv --verbose=4 "${APP_PATH}" 2>&1)"
+    if ! /usr/bin/grep -Fqx "Authority=${MACOS_CODESIGN_IDENTITY}" <<< "${SIGNATURE_DETAILS}"; then
+        echo "The app bundle was not signed by ${MACOS_CODESIGN_IDENTITY}." >&2
+        exit 1
+    fi
+fi
+
+echo "Built ${APP_PATH}"

--- a/MacOS/scripts/create_dmg.sh
+++ b/MacOS/scripts/create_dmg.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+PROJECT_DIR="$(cd -- "${MACOS_DIR}/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-${PROJECT_DIR}/.venv/bin/python}"
+APP_PATH="${1:-${MACOS_DIR}/dist/Amazon Music RPC.app}"
+OUTPUT_PATH="${2:-${MACOS_DIR}/dist/Amazon-Music-RPC.dmg}"
+SETTINGS_PATH="${MACOS_DIR}/dmg_settings.py"
+VOLUME_NAME="Amazon Music RPC"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "DMG creation requires macOS." >&2
+    exit 1
+fi
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+    echo "Python was not found at ${PYTHON_BIN}." >&2
+    exit 1
+fi
+if [[ ! -d "${APP_PATH}" || ! -f "${APP_PATH}/Contents/Info.plist" ]]; then
+    echo "Application bundle does not exist: ${APP_PATH}" >&2
+    echo "Run ${SCRIPT_DIR}/build_app.sh first." >&2
+    exit 1
+fi
+if [[ "${OUTPUT_PATH}" != *.dmg ]]; then
+    echo "Output path must end in .dmg: ${OUTPUT_PATH}" >&2
+    exit 1
+fi
+if ! "${PYTHON_BIN}" -c 'import dmgbuild' >/dev/null 2>&1; then
+    echo "dmgbuild is not installed. Run:" >&2
+    echo "  ${PYTHON_BIN} -m pip install -r ${MACOS_DIR}/requirements-build.txt" >&2
+    exit 1
+fi
+if [[ -n "${MACOS_NOTARYTOOL_PROFILE:-}" && -z "${MACOS_CODESIGN_IDENTITY:-}" ]]; then
+    echo "MACOS_NOTARYTOOL_PROFILE requires MACOS_CODESIGN_IDENTITY and a Developer ID build." >&2
+    exit 1
+fi
+
+/usr/bin/plutil -lint "${APP_PATH}/Contents/Info.plist" >/dev/null
+/usr/bin/codesign --verify --deep --strict "${APP_PATH}"
+if [[ -n "${MACOS_CODESIGN_IDENTITY:-}" ]]; then
+    SIGNATURE_DETAILS="$(/usr/bin/codesign -dv --verbose=4 "${APP_PATH}" 2>&1)"
+    if ! /usr/bin/grep -Fqx "Authority=${MACOS_CODESIGN_IDENTITY}" <<< "${SIGNATURE_DETAILS}"; then
+        echo "The app bundle was not signed by ${MACOS_CODESIGN_IDENTITY}." >&2
+        echo "Rebuild it with the same MACOS_CODESIGN_IDENTITY before creating a release DMG." >&2
+        exit 1
+    fi
+fi
+
+OUTPUT_DIR="$(dirname -- "${OUTPUT_PATH}")"
+/bin/mkdir -p -- "${OUTPUT_DIR}"
+TEMP_DIR="$(/usr/bin/mktemp -d "${OUTPUT_DIR}/.amazon-music-rpc-dmg.XXXXXX")"
+TEMP_DMG="${TEMP_DIR}/Amazon-Music-RPC.dmg"
+
+cleanup() {
+    /bin/rm -rf -- "${TEMP_DIR}"
+}
+trap cleanup EXIT
+
+"${PYTHON_BIN}" -m dmgbuild \
+    -s "${SETTINGS_PATH}" \
+    -D "app=${APP_PATH}" \
+    "${VOLUME_NAME}" \
+    "${TEMP_DMG}"
+
+/usr/bin/hdiutil verify "${TEMP_DMG}" >/dev/null
+
+if [[ -n "${MACOS_CODESIGN_IDENTITY:-}" ]]; then
+    /usr/bin/codesign --force --timestamp \
+        --sign "${MACOS_CODESIGN_IDENTITY}" "${TEMP_DMG}"
+    /usr/bin/codesign --verify --strict --verbose=2 "${TEMP_DMG}"
+fi
+
+/bin/mv -f -- "${TEMP_DMG}" "${OUTPUT_PATH}"
+
+if [[ -n "${MACOS_NOTARYTOOL_PROFILE:-}" ]]; then
+    /usr/bin/xcrun notarytool submit "${OUTPUT_PATH}" \
+        --keychain-profile "${MACOS_NOTARYTOOL_PROFILE}" --wait
+    /usr/bin/xcrun stapler staple "${OUTPUT_PATH}"
+    /usr/bin/xcrun stapler validate "${OUTPUT_PATH}"
+fi
+
+CHECKSUM_PATH="${OUTPUT_PATH}.sha256"
+CHECKSUM_TEMP="${TEMP_DIR}/$(basename -- "${CHECKSUM_PATH}")"
+CHECKSUM_VALUE="$(/usr/bin/shasum -a 256 "${OUTPUT_PATH}" | /usr/bin/awk '{print $1}')"
+/usr/bin/printf '%s  %s\n' "${CHECKSUM_VALUE}" "$(basename -- "${OUTPUT_PATH}")" > "${CHECKSUM_TEMP}"
+/bin/mv -f -- "${CHECKSUM_TEMP}" "${CHECKSUM_PATH}"
+
+echo "Created ${OUTPUT_PATH}"
+echo "Created ${CHECKSUM_PATH}"

--- a/MacOS/scripts/generate_icon.sh
+++ b/MacOS/scripts/generate_icon.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+PROJECT_DIR="$(cd -- "${MACOS_DIR}/.." && pwd)"
+SOURCE_ICON="${1:-${PROJECT_DIR}/Windows/icon.png}"
+OUTPUT_ICON="${2:-${MACOS_DIR}/build/assets/AmazonMusicRPC.icns}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "Icon generation requires macOS (sips and iconutil)." >&2
+    exit 1
+fi
+
+for tool in /usr/bin/sips /usr/bin/iconutil; do
+    if [[ ! -x "${tool}" ]]; then
+        echo "Required tool is unavailable: ${tool}" >&2
+        exit 1
+    fi
+done
+
+if [[ ! -f "${SOURCE_ICON}" ]]; then
+    echo "Source icon does not exist: ${SOURCE_ICON}" >&2
+    exit 1
+fi
+
+OUTPUT_DIR="$(dirname -- "${OUTPUT_ICON}")"
+/bin/mkdir -p -- "${OUTPUT_DIR}"
+TEMP_DIR="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/amazon-music-rpc-icon.XXXXXX")"
+
+cleanup() {
+    /bin/rm -rf -- "${TEMP_DIR}"
+}
+trap cleanup EXIT
+
+MASTER_ICON="${TEMP_DIR}/master.png"
+ICONSET_DIR="${TEMP_DIR}/AmazonMusicRPC.iconset"
+/bin/mkdir -- "${ICONSET_DIR}"
+
+/usr/bin/sips -s format png "${SOURCE_ICON}" --out "${MASTER_ICON}" >/dev/null
+
+read_dimension() {
+    /usr/bin/sips -g "$1" "${MASTER_ICON}" 2>/dev/null | /usr/bin/awk -F': ' -v key="$1" '$1 ~ key {print $2}'
+}
+
+WIDTH="$(read_dimension pixelWidth)"
+HEIGHT="$(read_dimension pixelHeight)"
+if [[ ! "${WIDTH}" =~ ^[0-9]+$ || ! "${HEIGHT}" =~ ^[0-9]+$ ]]; then
+    echo "Could not determine the source icon dimensions." >&2
+    exit 1
+fi
+if (( WIDTH < 1024 || HEIGHT < 1024 )); then
+    echo "The source icon must be at least 1024x1024; got ${WIDTH}x${HEIGHT}." >&2
+    exit 1
+fi
+
+make_icon() {
+    local pixels="$1"
+    local filename="$2"
+    /usr/bin/sips -z "${pixels}" "${pixels}" "${MASTER_ICON}" \
+        --out "${ICONSET_DIR}/${filename}" >/dev/null
+}
+
+make_icon 16 icon_16x16.png
+make_icon 32 icon_16x16@2x.png
+make_icon 32 icon_32x32.png
+make_icon 64 icon_32x32@2x.png
+make_icon 128 icon_128x128.png
+make_icon 256 icon_128x128@2x.png
+make_icon 256 icon_256x256.png
+make_icon 512 icon_256x256@2x.png
+make_icon 512 icon_512x512.png
+make_icon 1024 icon_512x512@2x.png
+
+TEMP_ICNS="${TEMP_DIR}/AmazonMusicRPC.icns"
+/usr/bin/iconutil -c icns "${ICONSET_DIR}" -o "${TEMP_ICNS}"
+/usr/bin/install -m 0644 "${TEMP_ICNS}" "${OUTPUT_ICON}"
+
+echo "Created ${OUTPUT_ICON} from ${SOURCE_ICON}"

--- a/MacOS/single_instance.py
+++ b/MacOS/single_instance.py
@@ -1,0 +1,146 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+"""One-instance lock and small owner-only command socket for the menu-bar app."""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import os
+import socket
+import stat
+import tempfile
+import threading
+from pathlib import Path
+
+from . import config
+
+
+ALLOWED_COMMANDS = {"settings", "diagnostics", "activate", "quit"}
+
+
+class SingleInstance:
+    def __init__(self, on_command=None, directory=None):
+        self.directory = Path(directory or config.CONFIG_DIR)
+        self.lock_path = self.directory / "instance.lock"
+        socket_path = self.directory / "instance.sock"
+        if len(os.fsencode(socket_path)) > 96:
+            digest = hashlib.sha256(os.fsencode(self.directory.resolve())).hexdigest()[:16]
+            socket_path = Path(tempfile.gettempdir()) / f"amrpc-{os.getuid()}-{digest}.sock"
+        self.socket_path = socket_path
+        self.on_command = on_command
+        self._lock_handle = None
+        self._server = None
+        self._thread = None
+        self._stopping = threading.Event()
+        self._owns_socket = False
+
+    def acquire(self):
+        self.directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            os.chmod(self.directory, 0o700)
+        except OSError:
+            pass
+        handle = self.lock_path.open("a+b")
+        os.chmod(self.lock_path, 0o600)
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            handle.close()
+            return False
+        self._lock_handle = handle
+        self._remove_stale_socket()
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            server.bind(str(self.socket_path))
+            self._owns_socket = True
+            os.chmod(self.socket_path, 0o600)
+            server.listen(4)
+            server.settimeout(0.5)
+        except Exception:
+            server.close()
+            self.close()
+            raise
+        self._server = server
+        self._thread = threading.Thread(target=self._serve, name="macos-instance-ipc", daemon=True)
+        self._thread.start()
+        return True
+
+    def _remove_stale_socket(self):
+        try:
+            info = self.socket_path.lstat()
+        except FileNotFoundError:
+            return
+        if not stat.S_ISSOCK(info.st_mode) or info.st_uid != os.getuid():
+            raise RuntimeError("Refusing to replace an untrusted instance socket path")
+        self.socket_path.unlink()
+
+    def _serve(self):
+        while not self._stopping.is_set() and self._server:
+            try:
+                client, _ = self._server.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            with client:
+                try:
+                    payload = client.recv(1024).decode("utf-8", errors="replace").strip()
+                except OSError:
+                    continue
+            if payload in ALLOWED_COMMANDS and self.on_command:
+                try:
+                    self.on_command(payload)
+                except Exception:
+                    pass
+
+    def notify(self, command="activate", timeout=1.5):
+        command = str(command or "").strip()
+        if command not in ALLOWED_COMMANDS:
+            raise ValueError("Unsupported instance command")
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(timeout)
+        try:
+            client.connect(str(self.socket_path))
+            client.sendall(command.encode("utf-8"))
+            return True
+        except OSError:
+            return False
+        finally:
+            client.close()
+
+    def close(self):
+        self._stopping.set()
+        if self._server:
+            try:
+                self._server.close()
+            except OSError:
+                pass
+            self._server = None
+        if self._thread and self._thread is not threading.current_thread():
+            self._thread.join(timeout=1.5)
+        self._thread = None
+        if self._lock_handle:
+            try:
+                fcntl.flock(self._lock_handle.fileno(), fcntl.LOCK_UN)
+                self._lock_handle.close()
+            except OSError:
+                pass
+            self._lock_handle = None
+        if self._owns_socket:
+            try:
+                info = self.socket_path.lstat()
+                if stat.S_ISSOCK(info.st_mode) and info.st_uid == os.getuid():
+                    self.socket_path.unlink()
+            except FileNotFoundError:
+                pass
+            self._owns_socket = False
+
+    def __enter__(self):
+        if not self.acquire():
+            raise RuntimeError("Amazon Music RPC is already running")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+        return False

--- a/MacOS/tests/test_amazon_devtools.py
+++ b/MacOS/tests/test_amazon_devtools.py
@@ -1,0 +1,534 @@
+# MIT License - Copyright (c) 2026 eripum9
+# pyright: reportMissingImports=false
+
+import inspect
+import plistlib
+from types import SimpleNamespace
+
+import pytest
+
+from MacOS import amazon_devtools
+
+
+def _target(**overrides):
+    value = {
+        "id": "page-123",
+        "type": "page",
+        "title": "Amazon Music",
+        "url": "https://music.amazon.de/morpho/webapp/index.html#/home",
+        "webSocketDebuggerUrl": "ws://127.0.0.1:52856/devtools/page/page-123",
+    }
+    value.update(overrides)
+    return value
+
+
+def _installation(tmp_path):
+    app = tmp_path / "Amazon Music.app"
+    executable = app / "Contents" / "MacOS" / "Amazon Music"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"test executable")
+    executable.chmod(0o755)
+    with (app / "Contents" / "Info.plist").open("wb") as stream:
+        plistlib.dump(
+            {
+                "CFBundleIdentifier": "com.amazon.music",
+                "CFBundleExecutable": "Amazon Music",
+                "CFBundleShortVersionString": "9.5.2",
+            },
+            stream,
+        )
+    return app
+
+
+def _metadata(**overrides):
+    value = {
+        "status": "found",
+        "title": "Treehome95 [Explicit]",
+        "artist": "Tyler, The Creator",
+        "album": "Wolf [Explicit]",
+        "art_url": "https://m.media-amazon.com/images/I/example.jpg",
+        "track_link": "https://music.amazon.de/albums/B00C3O5D3A?trackAsin=B00C3O5D3A",
+        "position": 138.25,
+        "duration": 179,
+        "playback_status": "paused",
+    }
+    value.update(overrides)
+    return value
+
+
+def test_validate_app_bundle_requires_expected_identity_and_executable(tmp_path):
+    app = _installation(tmp_path)
+    descriptor = amazon_devtools._validate_app_bundle(
+        app,
+        require_standard_location=False,
+        signature_checker=lambda path: path == app,
+    )
+    assert descriptor == {
+        "app_path": str(app),
+        "executable": str(app / "Contents" / "MacOS" / "Amazon Music"),
+        "bundle_id": "com.amazon.music",
+        "version": "9.5.2",
+    }
+
+    with (app / "Contents" / "Info.plist").open("wb") as stream:
+        plistlib.dump(
+            {"CFBundleIdentifier": "com.amazon.music.evil", "CFBundleExecutable": "Amazon Music"},
+            stream,
+        )
+    assert amazon_devtools._validate_app_bundle(
+        app,
+        require_standard_location=False,
+        signature_checker=lambda path: True,
+    ) is None
+
+
+def test_signature_identity_accepts_only_amazon_team_and_bundle():
+    def runner(command, **kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout="",
+            stderr=(
+                "Identifier=com.amazon.music\n"
+                "Authority=Developer ID Application: AMZN Mobile LLC (94KV3E626L)\n"
+                "TeamIdentifier=94KV3E626L\n"
+            ),
+        )
+
+    assert amazon_devtools._official_signature_identity(amazon_devtools.AMAZON_MUSIC_APP, runner)
+
+    def impostor(command, **kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout="",
+            stderr=(
+                "Identifier=com.amazon.music\n"
+                "Authority=Developer ID Application: AMZN Mobile LLC (EVIL)\n"
+                "TeamIdentifier=EVIL\n"
+            ),
+        )
+
+    assert not amazon_devtools._official_signature_identity(amazon_devtools.AMAZON_MUSIC_APP, impostor)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://music.amazon.de/morpho/webapp/index.html",
+        "https://www.amazon.de/gp/your-account",
+        "https://music.amazon.de.evil.test/morpho/webapp/index.html",
+        "https://music.amazon.invalid/morpho/webapp/index.html",
+        "https://user:password@music.amazon.de/morpho/webapp/index.html",
+        "https://music.amazon.de:8443/morpho/webapp/index.html",
+    ],
+)
+def test_page_target_rejects_untrusted_origins(url):
+    assert not amazon_devtools._is_amazon_music_target(_target(url=url))
+
+
+def test_page_target_accepts_only_exact_page_target_with_valid_id():
+    assert amazon_devtools._is_amazon_music_target(_target())
+    assert amazon_devtools._is_amazon_music_target(
+        _target(url="https://www.amazon.de/morpho/webapp")
+    )
+    assert not amazon_devtools._is_amazon_music_target(_target(type="service_worker"))
+    assert not amazon_devtools._is_amazon_music_target(_target(id="../../browser"))
+
+
+def test_websocket_target_is_bound_to_selected_loopback_page():
+    assert amazon_devtools._valid_target_websocket(_target(), 52856)
+    assert not amazon_devtools._valid_target_websocket(
+        _target(webSocketDebuggerUrl="ws://example.test:52856/devtools/page/page-123"),
+        52856,
+    )
+    assert not amazon_devtools._valid_target_websocket(
+        _target(webSocketDebuggerUrl="ws://127.0.0.1:52857/devtools/page/page-123"),
+        52856,
+    )
+    assert not amazon_devtools._valid_target_websocket(
+        _target(webSocketDebuggerUrl="ws://user:password@127.0.0.1:52856/devtools/page/page-123"),
+        52856,
+    )
+    assert not amazon_devtools._valid_target_websocket(
+        _target(webSocketDebuggerUrl="ws://127.0.0.1:52856/devtools/page/other"),
+        52856,
+    )
+    assert not amazon_devtools._valid_target_websocket(_target(), 9222)
+
+
+def test_private_port_selection_rejects_common_and_out_of_range_ports():
+    amazon_devtools.reset_devtools_port()
+    selected = amazon_devtools.get_devtools_port()
+    assert selected is not None
+    assert amazon_devtools.DEVTOOLS_PORT_MIN <= selected <= amazon_devtools.DEVTOOLS_PORT_MAX
+    with pytest.raises(ValueError):
+        amazon_devtools.set_devtools_port(9222)
+    amazon_devtools.reset_devtools_port()
+
+
+def test_owner_verification_fails_closed_and_rejects_other_process(monkeypatch):
+    installation: dict[str, object] = {"app_path": "/Applications/Amazon Music.app"}
+    monkeypatch.setattr(amazon_devtools, "_listener_pids", lambda port: [])
+    assert amazon_devtools._devtools_owner_trust(52856, installation)["status"] == "unavailable"
+
+    monkeypatch.setattr(amazon_devtools, "_listener_pids", lambda port: [44])
+    monkeypatch.setattr(amazon_devtools, "_is_trusted_amazon_pid", lambda pid, install: False)
+    rejected = amazon_devtools._devtools_owner_trust(52856, installation)
+    assert rejected["trusted"] is False
+    assert rejected["status"] == "rejected"
+
+    monkeypatch.setattr(amazon_devtools, "_is_trusted_amazon_pid", lambda pid, install: pid == 44)
+    assert amazon_devtools._devtools_owner_trust(52856, installation)["trusted"] is True
+
+
+def test_listener_discovery_enumerates_only_private_loopback_ports_with_trusted_owners(monkeypatch):
+    installation: dict[str, object] = {"app_path": "/Applications/Amazon Music.app"}
+    commands = []
+
+    def runner(command, **kwargs):
+        commands.append((command, kwargs))
+        return SimpleNamespace(
+            returncode=0,
+            stdout=(
+                "p41\nf10\nn127.0.0.1:52856\n"
+                "f11\nn[::1]:52857\n"
+                "f12\nn*:52858\n"
+                "f13\nn127.0.0.1:9222\n"
+                "p99\nf20\nn127.0.0.1:52856\n"
+                "pbad\nf30\nn127.0.0.1:52859\n"
+                "p41\nf31\nn10.0.0.2:52860\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        amazon_devtools,
+        "_is_trusted_amazon_pid",
+        lambda pid, install: pid == 41 and install is installation,
+    )
+    assert amazon_devtools._trusted_listener_ports(installation, runner) == [52857]
+    assert commands[0][0] == [
+        "/usr/sbin/lsof",
+        "-nP",
+        "-a",
+        "-iTCP",
+        "-sTCP:LISTEN",
+        "-Fpfn",
+    ]
+
+
+def test_discovery_probes_only_verified_owners_and_requires_one_match(monkeypatch):
+    installation: dict[str, object] = {"app_path": "/Applications/Amazon Music.app"}
+    page_probes = []
+    owner_checks = []
+    amazon_devtools.reset_devtools_port()
+    monkeypatch.setattr(amazon_devtools, "_trusted_listener_ports", lambda install: [52856, 52857])
+
+    def owner(port, install=None):
+        owner_checks.append(port)
+        return {"trusted": port == 52856}
+
+    def page(port, verify_owner=True):
+        page_probes.append((port, verify_owner))
+        return _target() if port == 52856 else None
+
+    monkeypatch.setattr(amazon_devtools, "_devtools_owner_trust", owner)
+    monkeypatch.setattr(amazon_devtools, "_page_target", page)
+    assert amazon_devtools.discover_devtools_port(installation) == 52856
+    assert page_probes == [(52856, False)]
+    assert owner_checks == [52856, 52856, 52857]
+    assert amazon_devtools.get_devtools_port(False) == 52856
+
+    amazon_devtools.reset_devtools_port()
+    monkeypatch.setattr(amazon_devtools, "_trusted_listener_ports", lambda install: [52856, 52857])
+    monkeypatch.setattr(
+        amazon_devtools,
+        "_devtools_owner_trust",
+        lambda port, install=None: {"trusted": True},
+    )
+    monkeypatch.setattr(amazon_devtools, "_page_target", lambda port, verify_owner=True: _target())
+    assert amazon_devtools.discover_devtools_port(installation) is None
+    assert amazon_devtools.get_devtools_port(False) is None
+
+
+def test_failed_discovery_is_briefly_negative_cached(monkeypatch):
+    installation: dict[str, object] = {"app_path": "/Applications/Amazon Music.app"}
+    scans = []
+    clock = [10.0]
+    amazon_devtools.reset_devtools_port()
+    monkeypatch.setattr(amazon_devtools.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        amazon_devtools,
+        "_trusted_listener_ports",
+        lambda install: scans.append(install) or [],
+    )
+    assert amazon_devtools.discover_devtools_port(installation) is None
+    clock[0] = 11.0
+    assert amazon_devtools.discover_devtools_port(installation) is None
+    clock[0] = 13.0
+    assert amazon_devtools.discover_devtools_port(installation) is None
+    assert scans == [installation, installation]
+
+
+def test_status_rediscovers_existing_listener_after_fresh_process(monkeypatch):
+    installation: dict[str, object] = {"app_path": "/Applications/Amazon Music.app"}
+    amazon_devtools.reset_devtools_port()
+    monkeypatch.setattr(amazon_devtools, "locate_amazon_music_app", lambda: installation)
+    monkeypatch.setattr(amazon_devtools, "_running_amazon_pids", lambda install: [42])
+    monkeypatch.setattr(amazon_devtools, "discover_devtools_port", lambda install: 52856)
+    monkeypatch.setattr(
+        amazon_devtools,
+        "_devtools_owner_trust",
+        lambda port, install=None: {"trusted": True},
+    )
+    monkeypatch.setattr(amazon_devtools, "_page_target", lambda port, verify_owner=True: _target())
+    status = amazon_devtools.get_devtools_status()
+    assert status["status"] == "ready"
+    assert status["port"] == 52856
+
+
+def test_normalise_metadata_reads_status_timing_art_and_direct_link():
+    track = amazon_devtools._normalise_track_payload(_metadata(), "de")
+    assert track == {
+        "status": "found",
+        "detail": "Amazon Music metadata found",
+        "source": "amazon_devtools",
+        "title": "Treehome95",
+        "artist": "Tyler, The Creator",
+        "album": "Wolf",
+        "art_url": "https://m.media-amazon.com/images/I/example.jpg",
+        "track_link": "https://music.amazon.de/albums/B00C3O5D3A?trackAsin=B00C3O5D3A",
+        "position": 138.25,
+        "duration": 179.0,
+        "playback_status": "paused",
+        "confidence": 98,
+    }
+
+
+def test_normalise_metadata_uses_transport_text_and_rejects_unsafe_urls():
+    track = amazon_devtools._normalise_track_payload(
+        _metadata(
+            artist="",
+            album="",
+            secondary="Tyler, The Creator • Wolf",
+            position=None,
+            duration=None,
+            position_text="2:18",
+            remaining_text="-0:41",
+            art_url="https://127.0.0.1/private",
+            track_link="https://music.amazon.de.evil.test/track",
+        ),
+        "de",
+    )
+    assert track["artist"] == "Tyler, The Creator"
+    assert track["album"] == "Wolf"
+    assert track["position"] == 138
+    assert track["duration"] == 179
+    assert track["art_url"] == ""
+    assert str(track["track_link"]).startswith("https://music.amazon.de/search/")
+
+
+def test_get_track_uses_read_only_runtime_evaluation_and_closes(monkeypatch):
+    calls = []
+
+    class Client:
+        def __init__(self, url, **kwargs):
+            calls.append(("init", url, kwargs))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            calls.append(("close",))
+
+        def request(self, method, params):
+            calls.append(("request", method, params))
+            return {"result": {"result": {"value": _metadata()}}}
+
+    monkeypatch.setattr(amazon_devtools, "_devtools_owner_trust", lambda *args, **kwargs: {"trusted": True})
+    monkeypatch.setattr(amazon_devtools, "_page_target", lambda *args, **kwargs: _target())
+    monkeypatch.setattr(amazon_devtools, "_CdpSocket", Client)
+    amazon_devtools._clear_cache()
+    track = amazon_devtools.get_devtools_track_sync("de", 52856)
+    assert track["status"] == "found"
+    assert track["port"] == 52856
+    assert calls[-1] == ("close",)
+    method_call = next(call for call in calls if call[0] == "request")
+    assert method_call[1] == "Runtime.evaluate"
+    assert method_call[2]["includeCommandLineAPI"] is False
+
+
+def test_get_track_rediscovers_existing_listener_after_fresh_process(monkeypatch):
+    class Client:
+        def __init__(self, url, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def request(self, method, params):
+            return {"result": {"result": {"value": _metadata()}}}
+
+    amazon_devtools.reset_devtools_port()
+    monkeypatch.setattr(amazon_devtools, "discover_devtools_port", lambda: 52856)
+    monkeypatch.setattr(amazon_devtools, "_devtools_owner_trust", lambda *args, **kwargs: {"trusted": True})
+    monkeypatch.setattr(amazon_devtools, "_page_target", lambda *args, **kwargs: _target())
+    monkeypatch.setattr(amazon_devtools, "_CdpSocket", Client)
+    result = amazon_devtools.get_devtools_track_sync("de")
+    assert result["status"] == "found"
+    assert result["port"] == 52856
+
+
+def test_devtools_failure_does_not_echo_sensitive_renderer_data(monkeypatch):
+    class Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def request(self, method, params):
+            raise RuntimeError("session_token=do-not-return")
+
+    monkeypatch.setattr(amazon_devtools, "_devtools_owner_trust", lambda *args, **kwargs: {"trusted": True})
+    monkeypatch.setattr(amazon_devtools, "_page_target", lambda *args, **kwargs: _target())
+    monkeypatch.setattr(amazon_devtools, "_CdpSocket", Client)
+    amazon_devtools._clear_cache()
+    result = amazon_devtools.get_devtools_track_sync(port=52856)
+    assert result["status"] == "error"
+    assert "do-not-return" not in str(result)
+
+
+def test_launch_requires_restart_without_terminating_running_app(monkeypatch):
+    installation = {"app_path": "/Applications/Amazon Music.app", "executable": "/Applications/Amazon Music.app/Contents/MacOS/Amazon Music"}
+    monkeypatch.setattr(amazon_devtools, "locate_amazon_music_app", lambda: installation)
+    monkeypatch.setattr(amazon_devtools, "_running_amazon_pids", lambda install: [42])
+    monkeypatch.setattr(amazon_devtools, "get_devtools_port", lambda create=False: None)
+    monkeypatch.setattr(amazon_devtools, "discover_devtools_port", lambda installation: None)
+    result = amazon_devtools.launch_amazon_music_devtools()
+    assert result["ok"] is False
+    assert result["restart_required"] is True
+
+
+def test_launch_reattaches_to_discovered_running_listener(monkeypatch):
+    installation = {
+        "app_path": "/Applications/Amazon Music.app",
+        "executable": "/Applications/Amazon Music.app/Contents/MacOS/Amazon Music",
+    }
+    monkeypatch.setattr(amazon_devtools, "locate_amazon_music_app", lambda: installation)
+    monkeypatch.setattr(amazon_devtools, "_running_amazon_pids", lambda install: [42])
+    monkeypatch.setattr(amazon_devtools, "get_devtools_port", lambda create=False: None)
+    monkeypatch.setattr(amazon_devtools, "discover_devtools_port", lambda install: 52856)
+    monkeypatch.setattr(amazon_devtools, "_page_target", lambda port: _target())
+    result = amazon_devtools.launch_amazon_music_devtools()
+    assert result == {
+        "ok": True,
+        "status": "ready",
+        "already_running": True,
+        "port": 52856,
+    }
+
+
+def test_launch_uses_loopback_flag_and_preserves_normal_profile(monkeypatch):
+    installation = {"app_path": "/Applications/Amazon Music.app", "executable": "/Applications/Amazon Music.app/Contents/MacOS/Amazon Music"}
+    launched = []
+
+    class Reservation:
+        def close(self):
+            launched.append(("reservation_closed",))
+
+    def launch_process(install, arguments, popen=None):
+        launched.append((install, arguments))
+        return SimpleNamespace(pid=4242)
+
+    monkeypatch.setattr(amazon_devtools, "locate_amazon_music_app", lambda: installation)
+    monkeypatch.setattr(amazon_devtools, "_running_amazon_pids", lambda install: [])
+    monkeypatch.setattr(amazon_devtools, "_reserve_devtools_port", lambda port=None: (52856, Reservation()))
+    monkeypatch.setattr(amazon_devtools, "_launch_process", launch_process)
+    monkeypatch.setattr(amazon_devtools, "_wait_for_page_target", lambda port, timeout, installation=None: _target())
+    monkeypatch.setattr(amazon_devtools, "_devtools_owner_trust", lambda *args, **kwargs: {"trusted": True, "status": "verified"})
+    result = amazon_devtools.launch_amazon_music_devtools()
+    assert result["ok"] is True
+    arguments = launched[1][1]
+    assert arguments == ["--remote-debugging-address=127.0.0.1", "--remote-debugging-port=52856"]
+    assert not any("user-data-dir" in argument for argument in arguments)
+
+
+def test_stop_signals_only_reverified_amazon_processes(monkeypatch):
+    installation = {
+        "app_path": "/Applications/Amazon Music.app",
+        "executable": "/Applications/Amazon Music.app/Contents/MacOS/Amazon Music",
+    }
+    reads = iter(([42, 43], []))
+    signals = []
+    monkeypatch.setattr(amazon_devtools, "locate_amazon_music_app", lambda: installation)
+    monkeypatch.setattr(
+        amazon_devtools,
+        "_running_amazon_pids",
+        lambda install, helpers=False: list(next(reads)),
+    )
+    monkeypatch.setattr(
+        amazon_devtools,
+        "_is_trusted_amazon_pid",
+        lambda pid, install: pid == 42,
+    )
+    monkeypatch.setattr(amazon_devtools.os, "kill", lambda pid, requested_signal: signals.append((pid, requested_signal)))
+    monkeypatch.setattr(amazon_devtools.time, "sleep", lambda seconds: None)
+    result = amazon_devtools.stop_amazon_music(timeout=0.1)
+    assert result["ok"] is True
+    assert signals == [(42, amazon_devtools.signal.SIGTERM)]
+
+
+def test_source_never_requests_browser_secrets_or_logs_them():
+    expression = amazon_devtools._TRANSPORT_EXPRESSION.lower()
+    source = inspect.getsource(amazon_devtools).lower()
+    for forbidden in (
+        "document.cookie",
+        "network.getallcookies",
+        "network.getcookies",
+        "storage.getcookies",
+        "localstorage",
+        "sessionstorage",
+    ):
+        assert forbidden not in expression
+    assert "import logging" not in source
+    assert 'print(' not in source
+
+
+def test_apply_devtools_metadata_matches_runtime_track_shape():
+    enhanced = amazon_devtools._normalise_track_payload(_metadata())
+    merged, changed = amazon_devtools.apply_devtools_to_track(
+        {"title": "Fallback", "artist": "", "status": "playing"},
+        enhanced,
+    )
+    assert changed is True
+    assert merged["title"] == "Treehome95"
+    assert merged["status"] == "paused"
+    assert str(merged["_amazon_art_url"]).startswith("https://m.media-amazon.com/")
+    assert str(merged["_amazon_track_link"]).startswith("https://music.amazon.de/")
+
+
+def test_process_launch_uses_argv_without_shell(monkeypatch):
+    calls = []
+
+    def popen(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(pid=1)
+
+    installation: dict[str, object] = {
+        "executable": "/Applications/Amazon Music.app/Contents/MacOS/Amazon Music",
+    }
+    amazon_devtools._launch_process(installation, ["--remote-debugging-port=52856"], popen)  # type: ignore[arg-type]
+    command, kwargs = calls[0]
+    assert command == [
+        "/Applications/Amazon Music.app/Contents/MacOS/Amazon Music",
+        "--remote-debugging-port=52856",
+    ]
+    assert kwargs["close_fds"] is True
+    assert "shell" not in kwargs
+    assert kwargs["stdout"] == amazon_devtools.subprocess.DEVNULL

--- a/MacOS/tests/test_config.py
+++ b/MacOS/tests/test_config.py
@@ -1,0 +1,114 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+import json
+import plistlib
+from types import SimpleNamespace
+
+import pytest
+
+from MacOS import config
+
+
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    store = {}
+    config_dir = tmp_path / "Application Support" / config.APP_NAME
+    monkeypatch.setattr(config, "CONFIG_DIR", str(config_dir))
+    monkeypatch.setattr(config, "CONFIG_PATH", str(config_dir / "config.json"))
+    monkeypatch.setattr(config, "LOG_PATH", str(config_dir / "console.log"))
+    monkeypatch.setattr(config, "LAUNCH_AGENT_PATH", str(tmp_path / "LaunchAgents" / "app.plist"))
+
+    def security(args, **kwargs):
+        command = args[0]
+        account = args[args.index("-a") + 1]
+        if command == "find-generic-password":
+            if account not in store:
+                return SimpleNamespace(returncode=44, stdout="", stderr="missing")
+            return SimpleNamespace(returncode=0, stdout=store[account] + "\n", stderr="")
+        if command == "add-generic-password":
+            store[account] = args[args.index("-w") + 1]
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if command == "delete-generic-password":
+            store.pop(account, None)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(config, "_security", security)
+    return config_dir, store
+
+
+def test_defaults_enable_devtools_primary_without_disruptive_auto_restart(isolated_config):
+    loaded = config.load_config()
+    assert loaded["amazon_devtools_enabled"] is True
+    assert loaded["amazon_devtools_auto_launch"] is False
+    assert loaded["show_paused"] is True
+    assert loaded["song_link_enabled"] is True
+
+
+def test_secrets_are_written_only_to_keychain(isolated_config):
+    config_dir, store = isolated_config
+    saved = config.update_config_fields(
+        {
+            "listenbrainz_token": "lb-secret",
+            "lastfm_session_key": "fm-secret",
+            "lastfm_enabled": True,
+        }
+    )
+    public = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+    assert "listenbrainz_token" not in public
+    assert "lastfm_session_key" not in public
+    assert store["listenbrainz_token"] == "lb-secret"
+    assert store["lastfm_session_key"] == "fm-secret"
+    assert config.load_config()["listenbrainz_token"] == "lb-secret"
+    assert saved[config.CONFIG_REVISION_KEY] == 1
+
+
+def test_revisions_prevent_lost_updates(isolated_config):
+    first = config.update_config_fields({"show_paused": False})
+    second = config.update_config_fields({"song_link_enabled": False})
+    first["show_paused"] = True
+    with pytest.raises(config.ConfigConflictError):
+        config.save_config(first)
+    assert config.load_config()["song_link_enabled"] is False
+    assert second[config.CONFIG_REVISION_KEY] == 2
+
+
+def test_plaintext_legacy_secret_is_migrated(isolated_config):
+    config_dir, store = isolated_config
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.json").write_text(
+        json.dumps({"listenbrainz_token": "legacy-token"}), encoding="utf-8"
+    )
+    assert config.load_config()["listenbrainz_token"] == "legacy-token"
+    assert store["listenbrainz_token"] == "legacy-token"
+    assert "listenbrainz_token" not in json.loads(
+        (config_dir / "config.json").read_text(encoding="utf-8")
+    )
+
+
+def test_redaction_removes_secret_values(isolated_config):
+    payload = {
+        "listenbrainz_token": "top-secret-token",
+        "message": "Authorization: Token top-secret-token",
+    }
+    redacted = config.redact_data(payload, payload)
+    assert redacted["listenbrainz_token"] == config.REDACTION_TEXT
+    assert "top-secret-token" not in redacted["message"]
+
+
+def test_startup_uses_launch_agent(isolated_config, monkeypatch):
+    monkeypatch.setattr(config.sys, "argv", ["/repo/MacOS/main.py"])
+    config.set_startup(True, start_minimized=True)
+    with open(config.LAUNCH_AGENT_PATH, "rb") as handle:
+        payload = plistlib.load(handle)
+    assert payload["Label"] == config.BUNDLE_IDENTIFIER
+    assert payload["RunAtLoad"] is True
+    assert payload["ProgramArguments"][-1] == "--startup"
+    assert config.is_startup_enabled() is True
+    config.set_startup(False)
+    assert config.is_startup_enabled() is False
+
+
+def test_unknown_setting_is_rejected(isolated_config):
+    with pytest.raises(KeyError):
+        config.update_config_fields({"not_a_setting": True})

--- a/MacOS/tests/test_media_reader.py
+++ b/MacOS/tests/test_media_reader.py
@@ -1,0 +1,111 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+import json
+import subprocess
+from types import SimpleNamespace
+
+from MacOS import media_reader
+
+
+def _payload(**overrides):
+    payload = {
+        "status": "found",
+        "bundle_identifier": "com.amazon.music",
+        "display_name": "Amazon Music",
+        "title": "Song",
+        "artist": "Artist",
+        "album": "Album",
+        "duration": 240,
+        "position": 30.5,
+        "playback_rate": 1,
+        "artwork_url": "https://images.example.test/art.jpg",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_parse_probe_payload_returns_normalized_track():
+    track = media_reader.parse_probe_payload(_payload())
+    assert track == {
+        "title": "Song",
+        "artist": "Artist",
+        "album": "Album",
+        "status": "playing",
+        "position": 30.5,
+        "duration": 240.0,
+        "art_url": "https://images.example.test/art.jpg",
+        "source": "macos_now_playing",
+    }
+
+
+def test_parse_probe_payload_rejects_other_players_and_missing_titles():
+    assert media_reader.parse_probe_payload(_payload(bundle_identifier="com.apple.Music")) is None
+    assert media_reader.parse_probe_payload(_payload(title="")) is None
+    assert media_reader.parse_probe_payload(_payload(status="not_amazon_music")) is None
+
+
+def test_parse_probe_payload_clamps_timing_and_marks_paused():
+    track = media_reader.parse_probe_payload(_payload(duration=120, position=500, playback_rate=0))
+    assert track["position"] == 120
+    assert track["duration"] == 120
+    assert track["status"] == "paused"
+
+
+def test_parse_probe_payload_rejects_non_finite_timing():
+    track = media_reader.parse_probe_payload(_payload(duration=float("inf"), position=float("nan")))
+    assert track["duration"] == 0
+    assert track["position"] is None
+
+
+def test_parse_probe_payload_accepts_only_safe_https_artwork():
+    assert media_reader.parse_probe_payload(_payload(artwork_url="http://example.test/art.jpg"))["art_url"] == ""
+    assert media_reader.parse_probe_payload(_payload(artwork_url="https://user:pass@example.test/art.jpg"))["art_url"] == ""
+    assert media_reader.parse_probe_payload(_payload(artwork_url="https://example.test:444/art.jpg"))["art_url"] == ""
+
+
+def test_get_track_sync_invokes_osascript_without_a_shell():
+    calls = []
+
+    def runner(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(returncode=0, stdout=json.dumps(_payload()), stderr="")
+
+    track = media_reader.get_track_sync(timeout=1.25, runner=runner, platform="darwin")
+    assert track["title"] == "Song"
+    assert calls == [
+        (
+            ["/usr/bin/osascript", "-l", "JavaScript", str(media_reader.PROBE_PATH)],
+            {"capture_output": True, "text": True, "timeout": 1.25},
+        )
+    ]
+
+
+def test_get_track_sync_fails_closed():
+    def timeout_runner(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    def malformed_runner(command, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="not json", stderr="")
+
+    assert media_reader.get_track_sync(runner=timeout_runner, platform="darwin") is None
+    assert media_reader.get_track_sync(runner=malformed_runner, platform="darwin") is None
+    assert media_reader.get_track_sync(runner=malformed_runner, platform="linux") is None
+
+
+def test_get_track_sync_rejects_oversized_output():
+    def oversized_runner(command, **kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=" " * (media_reader.MAX_PROBE_OUTPUT_BYTES + 1),
+            stderr="",
+        )
+
+    assert media_reader.get_track_sync(runner=oversized_runner, platform="darwin") is None
+
+
+def test_jxa_probe_is_owner_scoped_and_read_only():
+    source = media_reader.PROBE_PATH.read_text(encoding="utf-8")
+    assert "bundleIdentifier !== 'com.amazon.music'" in source
+    assert "MRNowPlayingRequest" in source
+    for forbidden in ("MRNowPlayingController", "sendCommand", "pauseCommand", "playCommand"):
+        assert forbidden not in source

--- a/MacOS/tests/test_packaging.py
+++ b/MacOS/tests/test_packaging.py
@@ -1,3 +1,5 @@
+# MIT License - Copyright (c) 2026 eripum9
+
 import plistlib
 import runpy
 import subprocess

--- a/MacOS/tests/test_packaging.py
+++ b/MacOS/tests/test_packaging.py
@@ -1,0 +1,106 @@
+import plistlib
+import runpy
+import subprocess
+from pathlib import Path
+
+
+MACOS_DIR = Path(__file__).resolve().parents[1]
+PROJECT_DIR = MACOS_DIR.parent
+
+
+def _read_plist(path):
+    with path.open("rb") as plist_file:
+        return plistlib.load(plist_file)
+
+
+def test_info_plist_has_stable_identity_and_no_unneeded_privacy_prompts():
+    payload = _read_plist(MACOS_DIR / "Info.plist")
+
+    assert payload["CFBundleDisplayName"] == "Amazon Music RPC"
+    assert payload["CFBundleIdentifier"] == "io.github.eripum9.amazon-music-rpc"
+    assert payload["LSMinimumSystemVersion"] == "12.0"
+    assert payload["LSUIElement"] is True
+    assert payload["CFBundleIconFile"] == "AmazonMusicRPC.icns"
+    assert "NSAppleEventsUsageDescription" not in payload
+    assert "NSLocalNetworkUsageDescription" not in payload
+
+
+def test_release_entitlements_do_not_weaken_hardened_runtime():
+    assert _read_plist(MACOS_DIR / "entitlements.plist") == {}
+
+
+def test_packaging_scripts_are_valid_bash():
+    for script_name in ("generate_icon.sh", "build_app.sh", "create_dmg.sh"):
+        script = MACOS_DIR / "scripts" / script_name
+        completed = subprocess.run(
+            ["/bin/bash", "-n", str(script)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stderr
+
+
+def test_dmg_layout_contains_applications_drop_target(tmp_path):
+    app_path = tmp_path / "Amazon Music RPC.app"
+    resources = app_path / "Contents" / "Resources"
+    resources.mkdir(parents=True)
+    icon_path = resources / "AmazonMusicRPC.icns"
+    icon_path.write_bytes(b"test icon")
+    info_path = app_path / "Contents" / "Info.plist"
+    with info_path.open("wb") as plist_file:
+        plistlib.dump({"CFBundleIconFile": icon_path.name}, plist_file)
+
+    settings = runpy.run_path(
+        str(MACOS_DIR / "dmg_settings.py"),
+        init_globals={"defines": {"app": str(app_path)}},
+    )
+
+    assert settings["files"] == [str(app_path)]
+    assert settings["symlinks"] == {"Applications": "/Applications"}
+    assert settings["icon_locations"] == {
+        "Amazon Music RPC.app": (150, 190),
+        "Applications": (450, 190),
+    }
+    assert settings["background"] == "builtin-arrow"
+    assert "hide_extensions" not in settings
+
+
+def test_spec_packages_the_shared_application_icon_and_macos_probe():
+    spec = (MACOS_DIR / "AmazonMusicRPC.spec").read_text(encoding="utf-8")
+
+    assert 'PROJECT_DIR / "Windows" / "icon.png"' in spec
+    assert 'MACOS_DIR / "amazon_music_now_playing.js"' in spec
+    assert 'collect_submodules("Shared")' in spec
+    assert 'collect_data_files("Shared")' in spec
+    assert 'str(PROJECT_DIR / "Windows")' in spec
+    assert '"Windows.discord_rpc"' in spec
+    assert 'bundle_identifier="io.github.eripum9.amazon-music-rpc"' in spec
+    assert 'MACOS_DIR / "main.py"' in spec
+
+
+def test_dmg_script_writes_checksum_after_optional_notarization():
+    script = (MACOS_DIR / "scripts" / "create_dmg.sh").read_text(encoding="utf-8")
+
+    assert 'CHECKSUM_PATH="${OUTPUT_PATH}.sha256"' in script
+    assert script.index("stapler validate") < script.index("CHECKSUM_VALUE=")
+    assert "/usr/bin/shasum -a 256" in script
+
+
+def test_runtime_and_build_requirements_are_pinned():
+    runtime = (MACOS_DIR / "requirements.txt").read_text(encoding="utf-8").splitlines()
+    build = (MACOS_DIR / "requirements-build.txt").read_text(encoding="utf-8").splitlines()
+
+    assert runtime == [
+        "pypresence==4.6.2",
+        "requests==2.34.2",
+        "Pillow==12.3.0",
+        "PySide6-Essentials==6.9.3",
+        "pylast==7.1.0",
+        "liblistenbrainz==0.7.0",
+    ]
+    assert build == [
+        "-r requirements.txt",
+        "PyInstaller==6.21.0",
+        "dmgbuild==1.6.7",
+    ]

--- a/MacOS/tests/test_runtime.py
+++ b/MacOS/tests/test_runtime.py
@@ -1,0 +1,433 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+from MacOS import config
+from MacOS.runtime import MacRuntime, RuntimeDependencies
+
+
+class Clock:
+    def __init__(self, value=1_000.0):
+        self.value = value
+
+    def __call__(self):
+        return self.value
+
+
+class FakeRPC:
+    def __init__(self, client_id):
+        self.client_id = client_id
+        self.connected = True
+        self.updates = []
+        self.clears = 0
+        self.shutdowns = 0
+
+    def update(self, **payload):
+        self.updates.append(payload)
+
+    def clear(self):
+        self.clears += 1
+
+    def shutdown(self):
+        self.shutdowns += 1
+        self.connected = False
+
+
+class FakeScrobbler:
+    def __init__(self, *args):
+        self.args = args
+        self.now_playing = []
+        self.scrobbles = []
+        self.closed = False
+
+    def update_now_playing(self, *args):
+        self.now_playing.append(args)
+
+    def scrobble(self, *args):
+        self.scrobbles.append(args)
+
+    def close(self):
+        self.closed = True
+
+
+def settings(**overrides):
+    value = {**config.DEFAULTS, config.CONFIG_REVISION_KEY: 0}
+    value.update(
+        {
+            "amazon_devtools_enabled": True,
+            "amazon_devtools_auto_launch": False,
+            "deezer_lookup_enabled": False,
+            "itunes_lookup_enabled": False,
+        }
+    )
+    value.update(overrides)
+    return value
+
+
+def track(**overrides):
+    value = {
+        "status": "found",
+        "title": "DevTools Song",
+        "artist": "Artist",
+        "album": "Album",
+        "art_url": "https://m.media-amazon.com/images/I/example.jpg",
+        "track_link": "https://music.amazon.com/tracks/ABCDEFGHIJ",
+        "position": 20,
+        "duration": 200,
+        "playback_status": "playing",
+        "source": "amazon_devtools",
+    }
+    value.update(overrides)
+    return value
+
+
+def build_runtime(
+    current_settings,
+    *,
+    devtools=None,
+    fallback=None,
+    clock=None,
+    amazon_running=False,
+    art_lookup=None,
+):
+    rpc_instances = []
+    lastfm_instances = []
+    listenbrainz_instances = []
+    restarts = []
+    fallback_calls = []
+
+    def rpc_factory(client_id):
+        instance = FakeRPC(client_id)
+        rpc_instances.append(instance)
+        return instance
+
+    def lastfm_factory(*args):
+        instance = FakeScrobbler(*args)
+        lastfm_instances.append(instance)
+        return instance
+
+    def listenbrainz_factory(*args):
+        instance = FakeScrobbler(*args)
+        listenbrainz_instances.append(instance)
+        return instance
+
+    def fallback_reader():
+        fallback_calls.append(True)
+        return fallback
+
+    dependencies = RuntimeDependencies(
+        discord_factory=rpc_factory,
+        lastfm_factory=lastfm_factory,
+        listenbrainz_factory=listenbrainz_factory,
+        art_lookup=art_lookup or (lambda *args, **kwargs: ("", "", "", 0)),
+        devtools_track=lambda *args: devtools,
+        devtools_launch=lambda: {"ok": False, "status": "restart_required", "restart_required": True},
+        devtools_restart=lambda: restarts.append(True) or {"ok": True, "status": "ready", "port": 55000},
+        devtools_status=lambda: {},
+        amazon_running=lambda: amazon_running,
+        now_playing_track=fallback_reader,
+        process_names=lambda: set(),
+        network_event=lambda *args: None,
+        clock=clock or Clock(),
+    )
+    runtime = MacRuntime(dependencies, settings_loader=lambda: current_settings)
+    return runtime, rpc_instances, lastfm_instances, listenbrainz_instances, restarts, fallback_calls
+
+
+def test_devtools_is_primary_and_builds_full_discord_payload():
+    runtime, rpcs, _, _, _, fallback_calls = build_runtime(settings(), devtools=track())
+    snapshot = runtime.tick()
+    assert fallback_calls == []
+    assert snapshot["source"] == "Amazon metadata"
+    assert snapshot["track"]["title"] == "DevTools Song"
+    payload = rpcs[0].updates[-1]
+    assert payload["album_name"] == "Album"
+    assert payload["album_art_url"].startswith("https://m.media-amazon.com/")
+    assert payload["start_ts"] == 980
+    assert payload["duration"] == 200
+    assert payload["buttons"][0]["label"] == "Listen on Amazon Music"
+
+
+def test_now_playing_is_used_only_when_devtools_is_unavailable():
+    fallback = {
+        "title": "Fallback Song",
+        "artist": "Fallback Artist",
+        "album": "Fallback Album",
+        "status": "playing",
+        "position": 5,
+        "duration": 100,
+        "source": "macos_now_playing",
+    }
+    runtime, _, _, _, _, fallback_calls = build_runtime(
+        settings(),
+        devtools={"status": "unavailable", "detail": "no listener"},
+        fallback=fallback,
+    )
+    snapshot = runtime.tick()
+    assert fallback_calls == [True]
+    assert snapshot["track"]["title"] == "Fallback Song"
+    assert snapshot["source"] == "macOS fallback"
+
+
+def test_pause_state_uses_pause_asset_and_respects_show_paused():
+    runtime, rpcs, _, _, _, _ = build_runtime(
+        settings(show_paused=True), devtools=track(playback_status="paused")
+    )
+    runtime.tick()
+    assert rpcs[0].updates[-1]["small_text"] == "Paused"
+    assert "pause_icon.png" in rpcs[0].updates[-1]["small_image"]
+
+    hidden_runtime, hidden_rpcs, _, _, _, _ = build_runtime(
+        settings(show_paused=False), devtools=track(playback_status="paused")
+    )
+    snapshot = hidden_runtime.tick()
+    assert hidden_rpcs[0].updates == []
+    assert snapshot["presence_visible"] is False
+
+
+def test_scrobblers_receive_now_playing_and_threshold_scrobble():
+    current = settings(
+        lastfm_enabled=True,
+        lastfm_session_key="session",
+        listenbrainz_enabled=True,
+        listenbrainz_token="token",
+    )
+    runtime, _, lastfm, listenbrainz, _, _ = build_runtime(
+        current, devtools=track(position=120, duration=200)
+    )
+    runtime.tick()
+    assert lastfm[0].now_playing[0][:3] == ("DevTools Song", "Artist", "Album")
+    assert listenbrainz[0].now_playing[0][:3] == ("DevTools Song", "Artist", "Album")
+    assert len(lastfm[0].scrobbles) == 1
+    assert len(listenbrainz[0].scrobbles) == 1
+
+
+def test_private_session_blocks_presence_and_scrobbling():
+    current = settings(
+        privacy_private_session=True,
+        privacy_disable_scrobbling=True,
+        lastfm_enabled=True,
+        lastfm_session_key="session",
+    )
+    runtime, rpcs, lastfm, _, _, _ = build_runtime(
+        current, devtools=track(position=150, duration=200)
+    )
+    snapshot = runtime.tick()
+    assert rpcs[0].updates == []
+    assert lastfm[0].now_playing == []
+    assert lastfm[0].scrobbles == []
+    assert snapshot["track"]["title"] == "Hidden by privacy controls"
+    assert snapshot["privacy"]["reason"] == "Private session enabled"
+    assert snapshot["raw_track"] == {}
+    assert snapshot["album_art_url"] == ""
+    assert snapshot["track_link"] == ""
+    assert "title" not in snapshot["amazon_devtools"]
+    assert "artist" not in snapshot["amazon_devtools"]
+
+
+def test_keyword_privacy_blocks_scrobbling_by_default():
+    current = settings(
+        privacy_blocked_keywords="devtools",
+        privacy_disable_scrobbling=True,
+        lastfm_enabled=True,
+        lastfm_session_key="session",
+    )
+    runtime, rpcs, lastfm, _, _, _ = build_runtime(
+        current, devtools=track(position=150, duration=200)
+    )
+    snapshot = runtime.tick()
+    assert rpcs[0].updates == []
+    assert lastfm[0].now_playing == []
+    assert lastfm[0].scrobbles == []
+    assert snapshot["raw_track"] == {}
+    assert "title" not in snapshot["amazon_devtools"]
+
+
+def test_hidden_track_never_leaks_to_artwork_when_scrobbling_is_allowed():
+    artwork_calls = []
+    current = settings(
+        privacy_private_session=True,
+        privacy_disable_scrobbling=False,
+        lastfm_enabled=True,
+        lastfm_session_key="session",
+    )
+    runtime, rpcs, lastfm, _, _, _ = build_runtime(
+        current,
+        devtools=track(art_url="", position=150, duration=200),
+        art_lookup=lambda *args, **kwargs: artwork_calls.append((args, kwargs))
+        or ("", "", "", 0),
+    )
+
+    snapshot = runtime.tick()
+    assert rpcs[0].updates == []
+    assert artwork_calls == []
+    assert lastfm[0].args[-1] is False
+    assert lastfm[0].now_playing
+    assert lastfm[0].scrobbles
+    assert snapshot["raw_track"] == {}
+
+
+def test_private_interval_never_counts_toward_later_scrobble():
+    clock = Clock(1_000)
+    current = settings(
+        lastfm_enabled=True,
+        lastfm_session_key="session",
+        privacy_disable_scrobbling=True,
+    )
+    current_track = {"value": track(position=20, duration=200)}
+    runtime, _, lastfm, _, _, _ = build_runtime(
+        current,
+        devtools=current_track["value"],
+        clock=clock,
+    )
+    runtime.dependencies.devtools_track = lambda *args: current_track["value"]
+
+    runtime.tick()
+    assert lastfm[0].now_playing
+
+    current["privacy_private_session"] = True
+    current_track["value"] = track(position=150, duration=200)
+    clock.value += 130
+    hidden = runtime.tick()
+    assert hidden["raw_track"] == {}
+    assert lastfm[0].scrobbles == []
+
+    current["privacy_private_session"] = False
+    visible_again = runtime.tick()
+    assert visible_again["track"]["title"] == "DevTools Song"
+    assert lastfm[0].scrobbles == []
+
+    current_track["value"] = track(position=199, duration=200)
+    clock.value += 49
+    runtime.tick()
+    assert lastfm[0].scrobbles == []
+
+
+def test_auto_launch_never_restarts_a_running_amazon_without_explicit_consent():
+    clock = Clock(1_000)
+    current = settings(amazon_devtools_auto_launch=True)
+    runtime, _, _, _, restarts, _ = build_runtime(
+        current,
+        devtools={"status": "unavailable", "detail": "no listener"},
+        fallback=None,
+        clock=clock,
+        amazon_running=True,
+    )
+    runtime.tick()
+    assert restarts == []
+    clock.value += 30
+    snapshot = runtime.tick()
+    assert restarts == []
+    assert snapshot["amazon_devtools"]["status"] == "restart_required"
+
+
+def test_disabling_listener_requires_an_explicit_runtime_action(monkeypatch):
+    current = settings()
+    runtime, _, _, _, _, _ = build_runtime(current, devtools=track())
+    calls = []
+    runtime.dependencies.devtools_disable = (
+        lambda **kwargs: calls.append(kwargs)
+        or {"ok": True, "status": "disabled", "stopped": [42]}
+    )
+    saved = {
+        **current,
+        "amazon_devtools_enabled": False,
+        "amazon_devtools_auto_launch": False,
+    }
+    monkeypatch.setattr(config, "update_config_fields", lambda updates: {**saved, **updates})
+    monkeypatch.setattr(runtime, "reload_config", lambda value: setattr(runtime, "_settings", value))
+
+    result = runtime.disable_enhanced_metadata(relaunch=True)
+    assert result["status"] == "disabled"
+    assert calls == [{"relaunch": True}]
+    assert runtime._settings["amazon_devtools_enabled"] is False
+    assert runtime._settings["amazon_devtools_auto_launch"] is False
+    assert runtime.snapshot()["amazon_devtools"]["enabled"] is False
+
+
+def test_no_track_clears_an_existing_presence():
+    state = {"value": track()}
+    current = settings()
+    runtime, rpcs, _, _, _, _ = build_runtime(current, devtools=None)
+    runtime.dependencies.devtools_track = lambda *args: state["value"]
+    runtime.tick()
+    assert rpcs[0].updates
+    state["value"] = {"status": "unavailable"}
+    runtime.dependencies.now_playing_track = lambda: None
+    snapshot = runtime.tick()
+    assert rpcs[0].clears == 1
+    assert snapshot["track"] is None
+    assert snapshot["raw_track"] == {}
+    assert snapshot["album_art_url"] == ""
+    assert snapshot["track_link"] == ""
+
+
+def test_enabling_private_session_immediately_clears_diagnostic_metadata(monkeypatch):
+    current = settings()
+    runtime, _, _, _, _, _ = build_runtime(current, devtools=track())
+    assert runtime.tick()["raw_track"]["title"] == "DevTools Song"
+
+    private_settings = {**current, "privacy_private_session": True}
+    monkeypatch.setattr(
+        config,
+        "update_config_fields",
+        lambda updates: {**private_settings, **updates},
+    )
+    monkeypatch.setattr(runtime, "reload_config", lambda saved: setattr(runtime, "_settings", saved))
+
+    runtime.set_private_session(True)
+    snapshot = runtime.snapshot()
+    assert snapshot["track"]["title"] == "Hidden by privacy controls"
+    assert snapshot["raw_track"] == {}
+    assert snapshot["album_art_url"] == ""
+    assert snapshot["track_link"] == ""
+    assert snapshot["correction_suggested"] is False
+    assert "title" not in snapshot["amazon_devtools"]
+
+
+def test_wrong_song_suggestion_matches_windows_game_mode_behavior():
+    suspicious = track(title="Same", artist="Same")
+    runtime, _, _, _, _, _ = build_runtime(settings(), devtools=suspicious)
+    assert runtime.tick()["correction_suggested"] is True
+
+    game_runtime, _, _, _, _, _ = build_runtime(
+        settings(game_mode_enabled=True), devtools=suspicious
+    )
+    assert game_runtime.tick()["correction_suggested"] is False
+
+    mapped_runtime, _, _, _, _, _ = build_runtime(
+        settings(
+            track_mappings={
+                "same|same": {
+                    "title": "Corrected",
+                    "artist": "Artist",
+                }
+            }
+        ),
+        devtools=suspicious,
+    )
+    snapshot = mapped_runtime.tick()
+    assert snapshot["correction_suggested"] is False
+    assert snapshot["track"]["title"] == "Corrected"
+
+
+def test_unremembered_correction_applies_for_only_the_runtime_session():
+    current = settings()
+    runtime, _, _, _, _, _ = build_runtime(current, devtools=track())
+    assert runtime.tick()["track"]["title"] == "DevTools Song"
+
+    runtime.apply_correction(
+        "DevTools Song",
+        "Artist",
+        {
+            "title": "Session Title",
+            "artist": "Session Artist",
+            "album": "Session Album",
+            "art_url": "https://m.media-amazon.com/images/I/session.jpg",
+            "track_link": "https://music.amazon.com/tracks/ABCDEFGHIJ",
+            "duration": 201,
+        },
+        remember=False,
+    )
+    snapshot = runtime.tick()
+    assert snapshot["track"]["title"] == "Session Title"
+    assert snapshot["track"]["artist"] == "Session Artist"
+    assert current["track_mappings"] == {}

--- a/MacOS/tests/test_single_instance.py
+++ b/MacOS/tests/test_single_instance.py
@@ -1,0 +1,51 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+import time
+
+import pytest
+
+from MacOS.single_instance import SingleInstance
+
+
+def test_only_one_instance_can_acquire_and_commands_reach_owner(tmp_path):
+    commands = []
+    owner = SingleInstance(commands.append, directory=tmp_path)
+    second = SingleInstance(directory=tmp_path)
+    try:
+        assert owner.acquire() is True
+        assert second.acquire() is False
+        assert second.notify("settings") is True
+        deadline = time.monotonic() + 2
+        while not commands and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert commands == ["settings"]
+    finally:
+        second.close()
+        owner.close()
+
+
+def test_owner_can_be_reacquired_after_clean_close(tmp_path):
+    first = SingleInstance(directory=tmp_path)
+    assert first.acquire() is True
+    first.close()
+    replacement = SingleInstance(directory=tmp_path)
+    try:
+        assert replacement.acquire() is True
+    finally:
+        replacement.close()
+
+
+def test_rejects_unknown_commands(tmp_path):
+    instance = SingleInstance(directory=tmp_path)
+    with pytest.raises(ValueError):
+        instance.notify("run-arbitrary-command")
+
+
+def test_refuses_to_replace_regular_file_at_socket_path(tmp_path):
+    instance = SingleInstance(directory=tmp_path)
+    instance.socket_path.write_text("do not delete", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="untrusted"):
+        instance.acquire()
+    assert instance.socket_path.read_text(encoding="utf-8") == "do not delete"
+    instance.socket_path.unlink()
+    instance.close()

--- a/MacOS/tests/test_ui_helpers.py
+++ b/MacOS/tests/test_ui_helpers.py
@@ -1,0 +1,167 @@
+import pytest
+
+from MacOS import config
+from MacOS.ui import (
+    UIValidationError,
+    clean_custom_albums,
+    diagnostic_document,
+    settings_export_payload,
+    settings_import_updates,
+    snapshot_rows,
+)
+from Shared.track_picker_ui import search_page, track_payload
+
+
+def test_clean_custom_albums_normalizes_aliases_and_empty_rows():
+    value = clean_custom_albums(
+        """[
+          {"album":" Album ","aliases":["Deluxe", "deluxe", " Live "],"art_url":"https://example.test/a.jpg"},
+          {"album":"", "aliases":[], "art_url":""}
+        ]"""
+    )
+
+    assert value == [
+        {
+            "album": "Album",
+            "aliases": ["Deluxe", "Live"],
+            "art_url": "https://example.test/a.jpg",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "value, message",
+    [
+        ("not json", "invalid"),
+        ({"album": "x"}, "array"),
+        ([{"album": "Album", "art_url": "file:///tmp/x.png"}], "HTTP"),
+        ([{"album": "Album"}], "artwork URL"),
+    ],
+)
+def test_clean_custom_albums_rejects_unsafe_or_invalid_rows(value, message):
+    with pytest.raises(UIValidationError, match=message):
+        clean_custom_albums(value)
+
+
+def test_settings_export_secrets_are_explicit_opt_in():
+    settings = {
+        **config.DEFAULTS,
+        "listenbrainz_token": "lb-secret-value",
+        "lastfm_session_key": "lastfm-session-value",
+    }
+
+    public = settings_export_payload(settings, False, "2026-07-20T12:00:00+00:00")
+    private = settings_export_payload(settings, True, "2026-07-20T12:00:00+00:00")
+
+    assert public["format"] == "AmazonMusicRPC.settings"
+    assert public["include_tokens"] is False
+    assert public["includes_secrets"] is False
+    assert "listenbrainz_token" not in public["config"]
+    assert "lastfm_session_key" not in public["config"]
+    assert private["config"]["listenbrainz_token"] == "lb-secret-value"
+    assert private["config"]["lastfm_session_key"] == "lastfm-session-value"
+    assert private["include_tokens"] is True
+
+
+def test_settings_import_accepts_wrapper_ignores_unknown_and_normalizes():
+    updates = settings_import_updates(
+        {
+            "format": "amazon-music-rpc-settings",
+            "config": {
+                "show_paused": False,
+                "amazon_music_link_region": ".DE",
+                "discord_status_display": "unexpected",
+                "future_setting": "ignored",
+            },
+        }
+    )
+
+    assert updates == {
+        "show_paused": False,
+        "amazon_music_link_region": "de",
+        "discord_status_display": "artist",
+    }
+
+
+def test_settings_import_does_not_coerce_ambiguous_boolean():
+    with pytest.raises(UIValidationError, match="show_paused"):
+        settings_import_updates({"show_paused": "false"})
+
+
+def test_wrapped_import_only_accepts_secrets_when_declared():
+    hidden = settings_import_updates(
+        {"config": {"listenbrainz_token": "secret", "show_paused": True}}
+    )
+    included = settings_import_updates(
+        {
+            "include_tokens": True,
+            "config": {"listenbrainz_token": "secret", "show_paused": True},
+        }
+    )
+
+    assert "listenbrainz_token" not in hidden
+    assert included["listenbrainz_token"] == "secret"
+
+
+def test_snapshot_rows_surface_live_service_and_privacy_state():
+    rows = snapshot_rows(
+        {
+            "rpc_status": "running",
+            "discord_status": "connected",
+            "presence_visible": True,
+            "source": "Amazon metadata",
+            "amazon_devtools": {"detail": "Loopback endpoint found"},
+            "scrobbling": {"lastfm": "active", "listenbrainz": "missing_token"},
+            "privacy": {"hidden": True, "reason": "Matched privacy keyword"},
+        }
+    )
+
+    assert rows[0][0:2] == ("Runtime", "running")
+    assert rows[1][0:2] == ("Discord", "connected")
+    assert rows[3][1] == "active"
+    assert rows[4][1] == "missing_token"
+    assert rows[5][1:] == ("hidden", "Matched privacy keyword")
+
+
+def test_diagnostic_document_redacts_runtime_and_omits_secret_settings(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "credential_storage_status",
+        lambda: {"keychain_available": True, "keychain_keys": ["listenbrainz_token"]},
+    )
+    settings = {
+        **config.DEFAULTS,
+        "listenbrainz_token": "super-secret-token",
+        "lastfm_session_key": "lastfm-secret-token",
+    }
+    document = diagnostic_document(
+        {"last_error": "Authorization: Token super-secret-token"},
+        settings,
+        [{"detail": "super-secret-token"}],
+        "2026-07-20T12:00:00+00:00",
+    )
+
+    serialized = str(document)
+    assert "super-secret-token" not in serialized
+    assert "lastfm-secret-token" not in serialized
+    assert "[redacted]" in serialized
+    assert "listenbrainz_token" not in document["settings"]
+
+
+def test_shared_track_payload_and_legacy_search_paging():
+    calls = []
+
+    def legacy_search(query, limit):
+        calls.append((query, limit))
+        return [{"title": "Only result", "duration": "12.5"}]
+
+    assert search_page("song artist", 5, 1, legacy_search) == []
+    assert calls == []
+    assert track_payload({"title": "  Song ", "duration": "12.5"}) == {
+        "title": "Song",
+        "artist": "",
+        "album": "",
+        "art_url": "",
+        "track_link": "",
+        "duration": 12.5,
+    }

--- a/MacOS/tests/test_ui_helpers.py
+++ b/MacOS/tests/test_ui_helpers.py
@@ -1,3 +1,5 @@
+# MIT License - Copyright (c) 2026 eripum9
+
 import pytest
 
 from MacOS import config

--- a/MacOS/tests/test_updater.py
+++ b/MacOS/tests/test_updater.py
@@ -1,0 +1,144 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+import hashlib
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from MacOS import updater
+
+
+class Response:
+    def __init__(self, *, data=None, content=b"", status=200, headers=None, chunks=None):
+        self._data = data
+        self.content = content
+        self.status_code = status
+        self.headers = headers or {}
+        self._chunks = chunks if chunks is not None else [content]
+        self.closed = False
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def close(self):
+        self.closed = True
+
+    def iter_content(self, chunk_size):
+        yield from self._chunks
+
+
+def asset_url(name):
+    return f"https://github.com/{updater.REPO}/releases/download/v5.1.0/{name}"
+
+
+def release_data(checksum):
+    return {
+        "tag_name": "v5.1.0",
+        "html_url": f"https://github.com/{updater.REPO}/releases/tag/v5.1.0",
+        "body": "## What's new\n- macOS beta",
+        "assets": [
+            {
+                "name": updater.DMG_NAME,
+                "size": 12345,
+                "browser_download_url": asset_url(updater.DMG_NAME),
+            },
+            {
+                "name": updater.CHECKSUM_NAME,
+                "size": 90,
+                "browser_download_url": asset_url(updater.CHECKSUM_NAME),
+            },
+        ],
+        "checksum": checksum,
+    }
+
+
+def test_check_for_update_requires_exact_dmg_and_reads_checksum(monkeypatch):
+    checksum = "a" * 64
+    responses = [
+        Response(data=release_data(checksum), content=b"{}"),
+        Response(content=f"{checksum}  {updater.DMG_NAME}\n".encode()),
+    ]
+
+    def request_get(*args, **kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(updater, "_network_event", lambda *args: None)
+    update = updater.check_for_update(request_get=request_get)
+    assert update.available is True
+    assert update.version == "5.1.0"
+    assert update.dmg_url.endswith(updater.DMG_NAME)
+    assert update.expected_sha256 == checksum
+    assert "macOS beta" in update.changelog
+
+
+def test_check_for_update_reports_up_to_date(monkeypatch):
+    response = Response(
+        data={
+            "tag_name": "v5.0.0",
+            "html_url": f"https://github.com/{updater.REPO}/releases/tag/v5.0.0",
+            "assets": [],
+        },
+        content=b"{}",
+    )
+    monkeypatch.setattr(updater, "_network_event", lambda *args: None)
+    update = updater.check_for_update(request_get=lambda *args, **kwargs: response)
+    assert update.available is False
+    assert update.error == ""
+
+
+def test_check_for_update_rejects_untrusted_release_metadata(monkeypatch):
+    monkeypatch.setattr(updater, "_network_event", lambda *args: None)
+    update = updater.check_for_update(
+        request_get=lambda *args, **kwargs: Response(data=[], content=b"[]")
+    )
+    assert update.available is False
+    assert "invalid" in update.error.lower()
+
+
+def test_download_dmg_verifies_sha256_and_opens_verified_path(monkeypatch):
+    payload = b"verified dmg bytes"
+    checksum = hashlib.sha256(payload).hexdigest()
+    update = updater.UpdateInfo(
+        available=True,
+        version="5.1.0",
+        dmg_url=asset_url(updater.DMG_NAME),
+        expected_sha256=checksum,
+    )
+    response = Response(chunks=[payload[:5], payload[5:]])
+    monkeypatch.setattr(updater, "_network_event", lambda *args: None)
+    downloaded = updater.download_dmg(
+        update, request_get=lambda *args, **kwargs: response
+    )
+    assert downloaded.sha256 == checksum
+    calls = []
+    updater.open_dmg(
+        downloaded,
+        runner=lambda command, **kwargs: calls.append((command, kwargs)) or SimpleNamespace(pid=1),
+    )
+    assert calls[0][0] == ["/usr/bin/open", os.path.realpath(downloaded.path)]
+
+
+def test_download_dmg_rejects_missing_checksum():
+    update = updater.UpdateInfo(
+        available=True,
+        version="5.1.0",
+        dmg_url=asset_url(updater.DMG_NAME),
+    )
+    with pytest.raises(ValueError, match="SHA256"):
+        updater.download_dmg(update)
+
+
+def test_asset_validation_rejects_lookalike_hosts_and_names():
+    assert updater._valid_asset(asset_url(updater.DMG_NAME), updater.DMG_NAME)
+    assert not updater._valid_asset(
+        f"https://github.example/{updater.REPO}/releases/download/v5.1.0/{updater.DMG_NAME}",
+        updater.DMG_NAME,
+    )
+    assert not updater._valid_asset(
+        asset_url("Not-The-App.dmg"), updater.DMG_NAME
+    )

--- a/MacOS/ui.py
+++ b/MacOS/ui.py
@@ -1,0 +1,1632 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+"""Native PySide6 settings, diagnostics, and correction UI for macOS."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+import webbrowser
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlencode
+
+from PySide6.QtCore import QObject, QRunnable, Qt, QThreadPool, QTimer, Signal
+from PySide6.QtGui import QCloseEvent, QDesktopServices, QIcon, QKeySequence
+from PySide6.QtCore import QUrl
+from PySide6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QComboBox,
+    QFileDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QMessageBox,
+    QPlainTextEdit,
+    QPushButton,
+    QScrollArea,
+    QTabWidget,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+try:
+    from . import config
+except ImportError:  # Direct development execution.
+    import config
+
+from Shared.track_picker_ui import (
+    show_choice_picker,
+    show_correction_dialog,
+    show_input_picker,
+    show_wrong_song_dialog,
+)
+
+
+ISSUES_URL = "https://github.com/eripum9/Amazon-Music-Discord-RPC/issues/new"
+RELEASES_URL = "https://github.com/eripum9/Amazon-Music-Discord-RPC/releases/latest"
+LISTENBRAINZ_SETTINGS_URL = "https://listenbrainz.org/settings/"
+NETWORK_HISTORY_PATH = str(Path(config.CONFIG_DIR) / "network-history.json")
+
+COLORS = {
+    "background": "#17181b",
+    "surface": "#1e1f23",
+    "card": "#25262b",
+    "input": "#191a1e",
+    "border": "#3a3c43",
+    "border_light": "#494c54",
+    "text": "#f2f3f5",
+    "muted": "#a5a9b2",
+    "accent": "#5865f2",
+    "accent_hover": "#4752c4",
+    "success": "#3ba55d",
+    "warning": "#faa61a",
+    "error": "#ed4245",
+}
+
+APP_STYLE = f"""
+QMainWindow, QDialog, QWidget#appRoot {{ background: {COLORS['background']}; color: {COLORS['text']}; }}
+QWidget {{ color: {COLORS['text']}; font-size: 13px; }}
+QLabel[muted="true"] {{ color: {COLORS['muted']}; }}
+QLabel[heading="true"] {{ font-size: 22px; font-weight: 700; }}
+QLabel[cardTitle="true"] {{ font-size: 15px; font-weight: 700; }}
+QFrame#card {{ background: {COLORS['card']}; border: 1px solid {COLORS['border']}; border-radius: 10px; }}
+QFrame#statusCard {{ background: {COLORS['card']}; border: 1px solid {COLORS['border']}; border-radius: 10px; }}
+QLineEdit, QPlainTextEdit, QComboBox, QTableWidget {{
+    background: {COLORS['input']}; color: {COLORS['text']};
+    border: 1px solid {COLORS['border']}; border-radius: 7px; padding: 7px;
+    selection-background-color: {COLORS['accent']};
+}}
+QLineEdit:focus, QPlainTextEdit:focus, QComboBox:focus, QTableWidget:focus {{ border-color: {COLORS['accent']}; }}
+QComboBox::drop-down {{ border: 0; width: 24px; }}
+QPushButton {{
+    background: #34363c; color: {COLORS['text']}; border: 1px solid {COLORS['border_light']};
+    border-radius: 7px; padding: 7px 14px; font-weight: 600;
+}}
+QPushButton:hover {{ background: #404249; }}
+QPushButton:pressed {{ background: #2e3035; }}
+QPushButton:disabled {{ background: #26272b; color: #6f737c; border-color: #303238; }}
+QPushButton[primary="true"] {{ background: {COLORS['accent']}; border-color: {COLORS['accent']}; color: white; }}
+QPushButton[primary="true"]:hover {{ background: {COLORS['accent_hover']}; }}
+QPushButton[danger="true"] {{ background: transparent; color: #ff7376; border-color: #7a3437; }}
+QCheckBox {{ spacing: 9px; }}
+QCheckBox::indicator {{ width: 17px; height: 17px; }}
+QTabWidget::pane {{ border: 0; background: {COLORS['background']}; top: -1px; }}
+QTabBar::tab {{
+    color: {COLORS['muted']}; background: transparent; padding: 11px 15px;
+    border-bottom: 2px solid transparent; font-weight: 600;
+}}
+QTabBar::tab:selected {{ color: {COLORS['text']}; border-bottom-color: {COLORS['accent']}; }}
+QScrollArea {{ border: 0; background: transparent; }}
+QHeaderView::section {{
+    background: #2d2f34; color: {COLORS['muted']}; border: 0;
+    border-bottom: 1px solid {COLORS['border']}; padding: 7px; font-weight: 600;
+}}
+QTableWidget {{ gridline-color: {COLORS['border']}; }}
+QTableWidget::item {{ padding: 5px; }}
+QStatusBar {{ background: {COLORS['surface']}; color: {COLORS['muted']}; border-top: 1px solid {COLORS['border']}; }}
+QToolTip {{ background: #111215; color: {COLORS['text']}; border: 1px solid {COLORS['border_light']}; padding: 5px; }}
+"""
+
+
+class UIValidationError(ValueError):
+    """A user-facing settings validation error."""
+
+
+def _utc_timestamp():
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _string_list(value):
+    if isinstance(value, str):
+        value = value.replace("\n", ",").split(",")
+    if not isinstance(value, (list, tuple)):
+        return []
+    result = []
+    seen = set()
+    for item in value:
+        text = str(item or "").strip()
+        folded = text.casefold()
+        if text and folded not in seen:
+            result.append(text)
+            seen.add(folded)
+    return result
+
+
+def clean_custom_albums(value):
+    """Normalize the editable custom-artwork list.
+
+    ``value`` may be a decoded list or JSON text. Invalid JSON and invalid row
+    shapes are rejected before touching the configuration file.
+    """
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            value = json.loads(text)
+        except json.JSONDecodeError as error:
+            raise UIValidationError(f"Custom albums JSON is invalid: {error.msg}") from error
+    if value in (None, ""):
+        return []
+    if not isinstance(value, list):
+        raise UIValidationError("Custom albums must be a JSON array.")
+    cleaned = []
+    for index, entry in enumerate(value, start=1):
+        if not isinstance(entry, dict):
+            raise UIValidationError(f"Custom album row {index} must be an object.")
+        album = str(entry.get("album") or "").strip()
+        art_url = str(entry.get("art_url") or "").strip()
+        aliases = _string_list(entry.get("aliases") or [])
+        if not album and not art_url and not aliases:
+            continue
+        if not album:
+            raise UIValidationError(f"Custom album row {index} needs an album name.")
+        if not art_url:
+            raise UIValidationError(f"Custom album row {index} needs an artwork URL.")
+        if not art_url.lower().startswith(("https://", "http://")):
+            raise UIValidationError(f"Custom album row {index} artwork must use HTTP or HTTPS.")
+        cleaned.append({"album": album, "aliases": aliases, "art_url": art_url})
+    return cleaned
+
+
+def settings_export_payload(settings, include_secrets=False, exported_at=None):
+    """Build a portable settings document with secrets opt-in."""
+    settings = settings if isinstance(settings, dict) else {}
+    exported = {}
+    for key in config.DEFAULTS:
+        if key in config.SENSITIVE_CONFIG_KEYS and not include_secrets:
+            continue
+        if key not in settings:
+            continue
+        value = settings[key]
+        if key == "custom_albums":
+            value = clean_custom_albums(value)
+        exported[key] = value
+    return {
+        # Keep the Windows marker/flag for cross-platform imports while also
+        # carrying an explicit format version for future migrations.
+        "format": "AmazonMusicRPC.settings",
+        "format_version": 1,
+        "app_version": config.APP_VERSION,
+        "exported_at": exported_at or _utc_timestamp(),
+        "include_tokens": bool(include_secrets),
+        "includes_secrets": bool(include_secrets),
+        "config": exported,
+    }
+
+
+def settings_import_updates(payload):
+    """Validate an imported settings document and return known-key updates."""
+    if not isinstance(payload, dict):
+        raise UIValidationError("The imported file must contain a JSON object.")
+    source = payload.get("config", payload)
+    if not isinstance(source, dict):
+        raise UIValidationError("The imported config must be a JSON object.")
+    updates = {}
+    wrapped = source is not payload
+    includes_secrets = bool(payload.get("include_tokens") or payload.get("includes_secrets"))
+    for key, value in source.items():
+        if key not in config.DEFAULTS:
+            continue
+        if wrapped and key in config.SENSITIVE_CONFIG_KEYS and not includes_secrets:
+            continue
+        default = config.DEFAULTS[key]
+        if key == "custom_albums":
+            updates[key] = clean_custom_albums(value)
+        elif isinstance(default, bool):
+            if not isinstance(value, bool):
+                raise UIValidationError(f"{key} must be true or false.")
+            updates[key] = value
+        elif isinstance(default, int) and not isinstance(default, bool):
+            try:
+                updates[key] = int(value)
+            except (TypeError, ValueError) as error:
+                raise UIValidationError(f"{key} must be a whole number.") from error
+        elif isinstance(default, dict):
+            if not isinstance(value, dict):
+                raise UIValidationError(f"{key} must be an object.")
+            updates[key] = value
+        elif isinstance(default, list):
+            if not isinstance(value, list):
+                raise UIValidationError(f"{key} must be an array.")
+            updates[key] = value
+        else:
+            updates[key] = str(value or "")
+    if "discord_status_display" in updates:
+        updates["discord_status_display"] = config.normalize_discord_status_display(
+            updates["discord_status_display"]
+        )
+    if "amazon_music_link_region" in updates:
+        updates["amazon_music_link_region"] = config.normalize_amazon_music_link_region(
+            updates["amazon_music_link_region"]
+        )
+    return updates
+
+
+def snapshot_rows(snapshot):
+    """Flatten a runtime snapshot into stable diagnostics card rows."""
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    scrobbling = snapshot.get("scrobbling") or {}
+    privacy = snapshot.get("privacy") or {}
+    devtools = snapshot.get("amazon_devtools") or {}
+    return [
+        ("Runtime", str(snapshot.get("rpc_status") or "waiting"), str(snapshot.get("source_detail") or "")),
+        ("Discord", str(snapshot.get("discord_status") or snapshot.get("discord") or "waiting"), "Presence visible" if snapshot.get("presence_visible") else "Presence hidden or waiting"),
+        ("Metadata", str(snapshot.get("source") or "waiting"), str(devtools.get("detail") or snapshot.get("devtools_status") or "")),
+        ("Last.fm", str(scrobbling.get("lastfm") or "disabled"), "Scrobbling service"),
+        ("ListenBrainz", str(scrobbling.get("listenbrainz") or "disabled"), "Scrobbling service"),
+        ("Privacy", "hidden" if privacy.get("hidden") else ("private" if privacy.get("private_session") else "standard"), str(privacy.get("reason") or "No current privacy match")),
+    ]
+
+
+def _network_history(path=NETWORK_HISTORY_PATH):
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(value, list):
+        return []
+    return [entry for entry in value[-50:] if isinstance(entry, dict)]
+
+
+def diagnostic_document(snapshot, settings, network_events=None, generated_at=None):
+    """Create a redacted, shareable diagnostic JSON document."""
+    settings = settings if isinstance(settings, dict) else {}
+    public_settings = {
+        key: value
+        for key, value in settings.items()
+        if key in config.DEFAULTS and key not in config.SENSITIVE_CONFIG_KEYS
+    }
+    document = {
+        "format": "amazon-music-rpc-diagnostics",
+        "format_version": 1,
+        "generated_at": generated_at or _utc_timestamp(),
+        "app": {
+            "name": config.APP_DISPLAY_NAME,
+            "version": config.APP_VERSION,
+            "bundle_identifier": config.BUNDLE_IDENTIFIER,
+        },
+        "system": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+            "frozen": bool(getattr(sys, "frozen", False)),
+        },
+        "runtime": snapshot if isinstance(snapshot, dict) else {},
+        "settings": public_settings,
+        "credential_storage": config.credential_storage_status(),
+        "paths": {
+            "config": config.CONFIG_PATH,
+            "console_log": config.LOG_PATH,
+            "event_log": config.EVENT_LOG_PATH,
+            "runtime_diagnostics": config.DIAGNOSTICS_PATH,
+            "network_history": NETWORK_HISTORY_PATH,
+        },
+        "network_history": list(network_events or []),
+    }
+    return config.redact_data(document, settings)
+
+
+def _read_redacted_text(path, settings, max_bytes=120000):
+    try:
+        with open(path, "rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - max_bytes))
+            value = handle.read().decode("utf-8", errors="replace")
+    except OSError as error:
+        return f"{Path(path).name} is unavailable: {error}"
+    return config.redact_text(value, settings)
+
+
+def _write_private_json(path, payload):
+    """Atomically write user-exported JSON with owner-only permissions."""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".tmp", dir=target.parent
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, ensure_ascii=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _status_color(status):
+    status = str(status or "").casefold()
+    if status in {"running", "connected", "found", "active", "standard", "on"}:
+        return COLORS["success"]
+    if status in {"waiting", "retrying", "paused", "private", "hidden", "not_authenticated", "missing_token"}:
+        return COLORS["warning"]
+    if status in {"error", "stopped", "disconnected", "unavailable", "off"}:
+        return COLORS["error"]
+    return COLORS["muted"]
+
+
+class _WorkerSignals(QObject):
+    succeeded = Signal(object)
+    failed = Signal(str)
+
+
+class _Worker(QRunnable):
+    def __init__(self, function):
+        super().__init__()
+        self.function = function
+        self.signals = _WorkerSignals()
+
+    def run(self):
+        try:
+            value = self.function()
+        except Exception as error:
+            self.signals.failed.emit(f"{type(error).__name__}: {error}")
+        else:
+            self.signals.succeeded.emit(value)
+
+
+class _Card(QFrame):
+    def __init__(self, title, description="", parent=None):
+        super().__init__(parent)
+        self.setObjectName("card")
+        self.layout_box = QVBoxLayout(self)
+        self.layout_box.setContentsMargins(18, 16, 18, 17)
+        self.layout_box.setSpacing(11)
+        heading = QLabel(title)
+        heading.setProperty("cardTitle", True)
+        self.layout_box.addWidget(heading)
+        if description:
+            hint = QLabel(description)
+            hint.setProperty("muted", True)
+            hint.setWordWrap(True)
+            self.layout_box.addWidget(hint)
+
+
+def _scroll_tab():
+    scroll = QScrollArea()
+    scroll.setWidgetResizable(True)
+    content = QWidget()
+    content.setObjectName("appRoot")
+    layout = QVBoxLayout(content)
+    layout.setContentsMargins(20, 18, 20, 24)
+    layout.setSpacing(14)
+    scroll.setWidget(content)
+    return scroll, layout
+
+
+def _labelled_row(label, widget, hint=""):
+    row = QWidget()
+    layout = QVBoxLayout(row)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(5)
+    title = QLabel(label)
+    title.setStyleSheet("font-weight: 600;")
+    layout.addWidget(title)
+    layout.addWidget(widget)
+    if hint:
+        note = QLabel(hint)
+        note.setProperty("muted", True)
+        note.setWordWrap(True)
+        layout.addWidget(note)
+    return row
+
+
+class SettingsWindow(QMainWindow):
+    def __init__(self, coordinator):
+        super().__init__()
+        self.coordinator = coordinator
+        self.setObjectName("appRoot")
+        self.setStyleSheet(APP_STYLE)
+        self.setWindowTitle(f"{config.APP_DISPLAY_NAME} — Settings")
+        self.setMinimumSize(720, 620)
+        if coordinator.icon:
+            self.setWindowIcon(coordinator.icon)
+        saved = config.load_config()
+        self.resize(
+            max(720, int(saved.get("settings_window_width", 800))),
+            max(620, int(saved.get("settings_window_height", 760))),
+        )
+        self._build()
+        self.load_settings(saved)
+
+    def _build(self):
+        central = QWidget()
+        central.setObjectName("appRoot")
+        outer = QVBoxLayout(central)
+        outer.setContentsMargins(22, 18, 22, 16)
+        outer.setSpacing(10)
+        header = QHBoxLayout()
+        titles = QVBoxLayout()
+        heading = QLabel("Settings")
+        heading.setProperty("heading", True)
+        titles.addWidget(heading)
+        subtitle = QLabel("Control presence, metadata, privacy, and scrobbling.")
+        subtitle.setProperty("muted", True)
+        titles.addWidget(subtitle)
+        header.addLayout(titles)
+        header.addStretch(1)
+        version = QLabel(config.APP_VERSION)
+        version.setProperty("muted", True)
+        header.addWidget(version)
+        outer.addLayout(header)
+
+        self.tabs = QTabWidget()
+        self._build_general_tab()
+        self._build_privacy_tab()
+        self._build_scrobbling_tab()
+        self._build_artwork_tab()
+        self._build_advanced_tab()
+        outer.addWidget(self.tabs, 1)
+
+        footer = QHBoxLayout()
+        self.status = QLabel("")
+        self.status.setProperty("muted", True)
+        self.status.setWordWrap(True)
+        footer.addWidget(self.status, 1)
+        diagnostics = QPushButton("Diagnostics")
+        diagnostics.clicked.connect(self.coordinator.show_diagnostics)
+        footer.addWidget(diagnostics)
+        cancel = QPushButton("Reload")
+        cancel.clicked.connect(lambda: self.load_settings(config.load_config()))
+        footer.addWidget(cancel)
+        save = QPushButton("Save changes")
+        save.setProperty("primary", True)
+        save.setShortcut(QKeySequence.StandardKey.Save)
+        save.clicked.connect(self.save)
+        footer.addWidget(save)
+        outer.addLayout(footer)
+        self.setCentralWidget(central)
+
+    def _build_general_tab(self):
+        scroll, layout = _scroll_tab()
+        discord = _Card(
+            "Discord Rich Presence",
+            "The built-in application ID works immediately. A custom Discord application ID can use your own branding.",
+        )
+        self.custom_client = QCheckBox("Use a custom Discord application ID")
+        discord.layout_box.addWidget(self.custom_client)
+        self.client_id = QLineEdit()
+        self.client_id.setPlaceholderText(config.DEFAULT_CLIENT_ID)
+        self.client_id.setClearButtonEnabled(True)
+        discord.layout_box.addWidget(_labelled_row("Discord client ID", self.client_id, "Discord application IDs contain digits only."))
+        self.status_display = QComboBox()
+        for key, label in (("artist", "Artist"), ("album", "Album"), ("track", "Track"), ("application", "Application name")):
+            self.status_display.addItem(label, key)
+        discord.layout_box.addWidget(_labelled_row("Profile status display", self.status_display))
+        self.custom_client.toggled.connect(self.client_id.setEnabled)
+        layout.addWidget(discord)
+
+        startup = _Card("Startup", "Use a per-user LaunchAgent. No administrator access is needed.")
+        self.startup = QCheckBox("Start Amazon Music RPC when I log in")
+        self.start_minimized = QCheckBox("Start in the menu bar without opening Settings")
+        startup.layout_box.addWidget(self.startup)
+        startup.layout_box.addWidget(self.start_minimized)
+        layout.addWidget(startup)
+
+        playback = _Card("Playback display")
+        self.show_paused = QCheckBox("Show a paused status in Discord")
+        self.song_links = QCheckBox("Add a listen button to Discord presence")
+        playback.layout_box.addWidget(self.show_paused)
+        playback.layout_box.addWidget(self.song_links)
+        row = QHBoxLayout()
+        self.link_provider = QComboBox()
+        self.link_provider.addItem("Amazon Music", "amazon")
+        self.link_provider.addItem("Deezer when matched", "deezer")
+        row.addWidget(_labelled_row("Link provider", self.link_provider), 1)
+        self.region = QComboBox()
+        for region in config.AMAZON_MUSIC_LINK_REGIONS:
+            self.region.addItem(f"music.amazon.{region}", region)
+        row.addWidget(_labelled_row("Amazon region", self.region), 1)
+        playback.layout_box.addLayout(row)
+        layout.addWidget(playback)
+        layout.addStretch(1)
+        self.tabs.addTab(scroll, "General")
+
+    def _build_privacy_tab(self):
+        scroll, layout = _scroll_tab()
+        privacy = _Card(
+            "Privacy controls",
+            "Privacy filtering happens before metadata is sent to Discord or a scrobbling service.",
+        )
+        self.private_session = QCheckBox("Private session — hide all listening activity")
+        self.disable_private_scrobbling = QCheckBox("Also pause scrobbling while activity is private")
+        privacy.layout_box.addWidget(self.private_session)
+        privacy.layout_box.addWidget(self.disable_private_scrobbling)
+        self.blocked_keywords = QPlainTextEdit()
+        self.blocked_keywords.setMaximumHeight(100)
+        self.blocked_keywords.setPlaceholderText("podcast, audiobook, private artist")
+        privacy.layout_box.addWidget(
+            _labelled_row(
+                "Blocked title, artist, or album keywords",
+                self.blocked_keywords,
+                "Separate values with commas or new lines. Matching is case-insensitive.",
+            )
+        )
+        layout.addWidget(privacy)
+
+        game = _Card(
+            "Game mode",
+            "Suppress automatic wrong-song correction popups while active, without hiding presence.",
+        )
+        self.game_mode = QCheckBox("Enable game mode now")
+        game.layout_box.addWidget(self.game_mode)
+        self.game_processes = QPlainTextEdit()
+        self.game_processes.setMaximumHeight(95)
+        self.game_processes.setPlaceholderText("Minecraft, LeagueClient, steam_app_1234")
+        game.layout_box.addWidget(
+            _labelled_row(
+                "Process names",
+                self.game_processes,
+                "Comma-separated executable or app process names; file extensions are optional.",
+            )
+        )
+        layout.addWidget(game)
+        layout.addStretch(1)
+        self.tabs.addTab(scroll, "Privacy")
+
+    def _build_scrobbling_tab(self):
+        scroll, layout = _scroll_tab()
+        lastfm = _Card(
+            "Last.fm",
+            "Scrobble after 50% of a song or four minutes, with a 30-second minimum.",
+        )
+        self.lastfm_enabled = QCheckBox("Enable Last.fm scrobbling")
+        lastfm.layout_box.addWidget(self.lastfm_enabled)
+        self.lastfm_status = QLabel("")
+        self.lastfm_status.setProperty("muted", True)
+        lastfm.layout_box.addWidget(self.lastfm_status)
+        buttons = QHBoxLayout()
+        authenticate = QPushButton("Authenticate in browser")
+        authenticate.clicked.connect(self._lastfm_auth)
+        buttons.addWidget(authenticate)
+        complete = QPushButton("Complete authentication")
+        complete.setProperty("primary", True)
+        complete.clicked.connect(self._lastfm_complete)
+        buttons.addWidget(complete)
+        buttons.addStretch(1)
+        clear = QPushButton("Disconnect")
+        clear.setProperty("danger", True)
+        clear.clicked.connect(self._clear_lastfm)
+        buttons.addWidget(clear)
+        lastfm.layout_box.addLayout(buttons)
+        layout.addWidget(lastfm)
+
+        brainz = _Card(
+            "ListenBrainz",
+            "The user token is stored in macOS Keychain and is never written to config.json.",
+        )
+        self.listenbrainz_enabled = QCheckBox("Enable ListenBrainz scrobbling")
+        brainz.layout_box.addWidget(self.listenbrainz_enabled)
+        self.listenbrainz_token = QLineEdit()
+        self.listenbrainz_token.setEchoMode(QLineEdit.EchoMode.PasswordEchoOnEdit)
+        self.listenbrainz_token.setPlaceholderText("Paste your ListenBrainz user token")
+        brainz.layout_box.addWidget(_labelled_row("User token", self.listenbrainz_token))
+        self.listenbrainz_status = QLabel("")
+        self.listenbrainz_status.setProperty("muted", True)
+        brainz.layout_box.addWidget(self.listenbrainz_status)
+        actions = QHBoxLayout()
+        open_settings = QPushButton("Get token")
+        open_settings.clicked.connect(lambda: QDesktopServices.openUrl(QUrl(LISTENBRAINZ_SETTINGS_URL)))
+        actions.addWidget(open_settings)
+        validate = QPushButton("Validate token")
+        validate.setProperty("primary", True)
+        validate.clicked.connect(self._validate_listenbrainz)
+        actions.addWidget(validate)
+        actions.addStretch(1)
+        brainz.layout_box.addLayout(actions)
+        layout.addWidget(brainz)
+        layout.addStretch(1)
+        self.tabs.addTab(scroll, "Scrobbling")
+
+    def _build_artwork_tab(self):
+        scroll, layout = _scroll_tab()
+        lookup = _Card(
+            "Artwork lookup",
+            "Amazon metadata artwork is preferred. These providers fill gaps and are contacted only when needed.",
+        )
+        self.deezer_lookup = QCheckBox("Allow Deezer metadata and artwork lookup")
+        self.itunes_lookup = QCheckBox("Allow Apple iTunes Search artwork lookup")
+        lookup.layout_box.addWidget(self.deezer_lookup)
+        lookup.layout_box.addWidget(self.itunes_lookup)
+        layout.addWidget(lookup)
+
+        custom = _Card(
+            "Custom album artwork",
+            "Override artwork by album name. Aliases let remasters or alternate spellings share one image.",
+        )
+        self.custom_albums = QTableWidget(0, 3)
+        self.custom_albums.setHorizontalHeaderLabels(["Album", "Aliases", "Artwork URL"])
+        self.custom_albums.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        self.custom_albums.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        self.custom_albums.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+        self.custom_albums.verticalHeader().setVisible(False)
+        self.custom_albums.setMinimumHeight(240)
+        custom.layout_box.addWidget(self.custom_albums)
+        actions = QHBoxLayout()
+        add = QPushButton("Add album")
+        add.clicked.connect(self._add_album)
+        actions.addWidget(add)
+        remove = QPushButton("Remove selected")
+        remove.clicked.connect(self._remove_albums)
+        actions.addWidget(remove)
+        actions.addStretch(1)
+        custom.layout_box.addLayout(actions)
+        layout.addWidget(custom)
+        layout.addStretch(1)
+        self.tabs.addTab(scroll, "Artwork")
+
+    def _build_advanced_tab(self):
+        scroll, layout = _scroll_tab()
+        metadata = _Card(
+            "Enhanced Amazon metadata",
+            "Uses Chromium DevTools on a randomized loopback-only port. Turning off the checkbox stops RPC access, but an existing listener remains until Amazon Music is reopened normally.",
+        )
+        self.devtools_enabled = QCheckBox("Enable enhanced metadata")
+        self.devtools_auto = QCheckBox("Automatically start enhanced metadata when Amazon Music is closed")
+        metadata.layout_box.addWidget(self.devtools_enabled)
+        metadata.layout_box.addWidget(self.devtools_auto)
+        self.devtools_status = QLabel("")
+        self.devtools_status.setProperty("muted", True)
+        metadata.layout_box.addWidget(self.devtools_status)
+        actions = QHBoxLayout()
+        launch = QPushButton("Start enhanced metadata")
+        launch.setProperty("primary", True)
+        launch.clicked.connect(self._launch_devtools)
+        actions.addWidget(launch)
+        restart = QPushButton("Restart Amazon Music with DevTools")
+        restart.clicked.connect(lambda: self._launch_devtools(restart=True))
+        actions.addWidget(restart)
+        disable = QPushButton("Disable listener & reopen normally")
+        disable.clicked.connect(self._disable_devtools)
+        actions.addWidget(disable)
+        actions.addStretch(1)
+        metadata.layout_box.addLayout(actions)
+        layout.addWidget(metadata)
+
+        updates = _Card("Updates")
+        self.automatic_updates = QCheckBox("Check for updates automatically")
+        updates.layout_box.addWidget(self.automatic_updates)
+        check = QPushButton("Check now")
+        check.clicked.connect(self.coordinator.check_updates)
+        updates.layout_box.addWidget(check, 0, Qt.AlignmentFlag.AlignLeft)
+        layout.addWidget(updates)
+
+        data = _Card(
+            "Settings import and export",
+            "Exports exclude Keychain credentials unless you explicitly include them.",
+        )
+        self.include_secrets = QCheckBox("Include Last.fm and ListenBrainz credentials in exported JSON")
+        data.layout_box.addWidget(self.include_secrets)
+        row = QHBoxLayout()
+        export = QPushButton("Export settings…")
+        export.clicked.connect(self.export_settings)
+        row.addWidget(export)
+        import_button = QPushButton("Import settings…")
+        import_button.clicked.connect(self.import_settings)
+        row.addWidget(import_button)
+        row.addStretch(1)
+        data.layout_box.addLayout(row)
+        keychain = config.credential_storage_status()
+        storage = QLabel(
+            "Credential storage: macOS Keychain available"
+            if keychain.get("keychain_available")
+            else "Credential storage: macOS Keychain unavailable"
+        )
+        storage.setProperty("muted", True)
+        data.layout_box.addWidget(storage)
+        layout.addWidget(data)
+        layout.addStretch(1)
+        self.tabs.addTab(scroll, "Advanced")
+
+    def _combo_value(self, combo):
+        return combo.currentData() if combo.currentData() is not None else combo.currentText()
+
+    def _set_combo(self, combo, value):
+        index = combo.findData(value)
+        if index < 0:
+            index = combo.findText(str(value))
+        combo.setCurrentIndex(max(0, index))
+
+    def load_settings(self, settings):
+        self.settings = dict(settings or {})
+        self.custom_client.setChecked(bool(settings.get("use_custom_client_id")))
+        self.client_id.setText(str(settings.get("discord_client_id") or ""))
+        self.client_id.setEnabled(self.custom_client.isChecked())
+        self._set_combo(self.status_display, settings.get("discord_status_display", "artist"))
+        self.startup.setChecked(bool(settings.get("start_on_startup")))
+        self.start_minimized.setChecked(bool(settings.get("start_minimized", True)))
+        self.show_paused.setChecked(bool(settings.get("show_paused", True)))
+        self.song_links.setChecked(bool(settings.get("song_link_enabled", True)))
+        self._set_combo(self.link_provider, settings.get("song_link_provider", "amazon"))
+        self._set_combo(self.region, settings.get("amazon_music_link_region", "com"))
+        self.private_session.setChecked(bool(settings.get("privacy_private_session")))
+        self.disable_private_scrobbling.setChecked(bool(settings.get("privacy_disable_scrobbling", True)))
+        self.blocked_keywords.setPlainText(str(settings.get("privacy_blocked_keywords") or ""))
+        self.game_mode.setChecked(bool(settings.get("game_mode_enabled")))
+        self.game_processes.setPlainText(str(settings.get("game_mode_processes") or ""))
+        self.lastfm_enabled.setChecked(bool(settings.get("lastfm_enabled")))
+        username = str(settings.get("lastfm_username") or "")
+        self.lastfm_status.setText(f"Connected as {username}" if username else "Not authenticated")
+        self.listenbrainz_enabled.setChecked(bool(settings.get("listenbrainz_enabled")))
+        self.listenbrainz_token.setText(str(settings.get("listenbrainz_token") or ""))
+        self.listenbrainz_status.setText("Token saved in Keychain" if settings.get("listenbrainz_token") else "No token saved")
+        self.deezer_lookup.setChecked(bool(settings.get("deezer_lookup_enabled", True)))
+        self.itunes_lookup.setChecked(bool(settings.get("itunes_lookup_enabled", True)))
+        self._load_custom_albums(settings.get("custom_albums") or [])
+        self.devtools_enabled.setChecked(bool(settings.get("amazon_devtools_enabled", True)))
+        self.devtools_auto.setChecked(bool(settings.get("amazon_devtools_auto_launch", False)))
+        self.automatic_updates.setChecked(bool(settings.get("automatic_update_checks", True)))
+        self.status.setText("Settings loaded.")
+
+    def _load_custom_albums(self, albums):
+        try:
+            albums = clean_custom_albums(albums)
+        except UIValidationError:
+            albums = []
+        self.custom_albums.setRowCount(0)
+        for album in albums:
+            row = self.custom_albums.rowCount()
+            self.custom_albums.insertRow(row)
+            self.custom_albums.setItem(row, 0, QTableWidgetItem(album["album"]))
+            self.custom_albums.setItem(row, 1, QTableWidgetItem(", ".join(album["aliases"])))
+            self.custom_albums.setItem(row, 2, QTableWidgetItem(album["art_url"]))
+
+    def _custom_album_payload(self):
+        rows = []
+        for row in range(self.custom_albums.rowCount()):
+            values = []
+            for column in range(3):
+                item = self.custom_albums.item(row, column)
+                values.append(item.text().strip() if item else "")
+            rows.append({"album": values[0], "aliases": _string_list(values[1]), "art_url": values[2]})
+        return clean_custom_albums(rows)
+
+    def _add_album(self):
+        row = self.custom_albums.rowCount()
+        self.custom_albums.insertRow(row)
+        for column in range(3):
+            self.custom_albums.setItem(row, column, QTableWidgetItem(""))
+        self.custom_albums.setCurrentCell(row, 0)
+        self.custom_albums.editItem(self.custom_albums.item(row, 0))
+
+    def _remove_albums(self):
+        rows = sorted({item.row() for item in self.custom_albums.selectedItems()}, reverse=True)
+        for row in rows:
+            self.custom_albums.removeRow(row)
+
+    def values(self):
+        client_id = self.client_id.text().strip()
+        if self.custom_client.isChecked() and (not client_id.isdigit() or not 16 <= len(client_id) <= 24):
+            raise UIValidationError("Custom Discord client ID must contain 16–24 digits.")
+        return {
+            "use_custom_client_id": self.custom_client.isChecked(),
+            "discord_client_id": client_id or config.DEFAULT_CLIENT_ID,
+            "discord_status_display": self._combo_value(self.status_display),
+            "start_on_startup": self.startup.isChecked(),
+            "start_minimized": self.start_minimized.isChecked(),
+            "show_paused": self.show_paused.isChecked(),
+            "song_link_enabled": self.song_links.isChecked(),
+            "song_link_provider": self._combo_value(self.link_provider),
+            "amazon_music_link_region": self._combo_value(self.region),
+            "privacy_private_session": self.private_session.isChecked(),
+            "privacy_disable_scrobbling": self.disable_private_scrobbling.isChecked(),
+            "privacy_blocked_keywords": self.blocked_keywords.toPlainText().strip(),
+            "game_mode_enabled": self.game_mode.isChecked(),
+            "game_mode_processes": self.game_processes.toPlainText().strip(),
+            "lastfm_enabled": self.lastfm_enabled.isChecked(),
+            "listenbrainz_enabled": self.listenbrainz_enabled.isChecked(),
+            "listenbrainz_token": self.listenbrainz_token.text().strip(),
+            "deezer_lookup_enabled": self.deezer_lookup.isChecked(),
+            "itunes_lookup_enabled": self.itunes_lookup.isChecked(),
+            "custom_albums": self._custom_album_payload(),
+            "amazon_devtools_enabled": self.devtools_enabled.isChecked(),
+            "amazon_devtools_auto_launch": self.devtools_auto.isChecked(),
+            "automatic_update_checks": self.automatic_updates.isChecked(),
+        }
+
+    def save(self):
+        try:
+            values = self.values()
+            values.update(
+                {
+                    "intro_seen": True,
+                    "setup_wizard_seen": True,
+                    "setup_wizard_version": config.APP_VERSION,
+                }
+            )
+            saved = config.update_config_fields(values)
+            config.set_startup(saved.get("start_on_startup"), saved.get("start_minimized"))
+            self.coordinator.runtime_reload(saved)
+            self.settings = saved
+        except Exception as error:
+            QMessageBox.warning(self, "Could not save settings", str(error))
+            self.status.setText(f"Save failed: {error}")
+            return False
+        self.status.setText("Settings saved. Runtime reloaded.")
+        return True
+
+    def _lastfm_auth(self):
+        self.status.setText("Starting Last.fm authentication…")
+        self.coordinator.lastfm_auth(
+            lambda result: self.status.setText(
+                "Browser opened. Approve access, then click Complete authentication."
+                if result.get("ok")
+                else result.get("error", "Authentication failed.")
+            )
+        )
+
+    def _lastfm_complete(self):
+        self.status.setText("Completing Last.fm authentication…")
+
+        def done(result):
+            if result.get("ok"):
+                self.lastfm_enabled.setChecked(True)
+                self.lastfm_status.setText(f"Connected as {result.get('username') or 'Last.fm user'}")
+                self.load_settings(config.load_config())
+            else:
+                self.status.setText(result.get("error", "Authentication failed."))
+
+        self.coordinator.lastfm_complete(done)
+
+    def _clear_lastfm(self):
+        saved = config.update_config_fields(
+            {"lastfm_enabled": False, "lastfm_session_key": "", "lastfm_username": ""}
+        )
+        self.coordinator.runtime_reload(saved)
+        self.load_settings(saved)
+        self.status.setText("Last.fm disconnected.")
+
+    def _validate_listenbrainz(self):
+        token = self.listenbrainz_token.text().strip()
+        if not token:
+            self.listenbrainz_status.setText("Paste a token first.")
+            return
+        self.listenbrainz_status.setText("Validating…")
+
+        def done(result):
+            if result.get("valid"):
+                self.listenbrainz_status.setText(f"Valid token for {result.get('user_name') or 'ListenBrainz user'}")
+                self.listenbrainz_enabled.setChecked(True)
+            else:
+                self.listenbrainz_status.setText(result.get("error") or "Invalid token")
+
+        self.coordinator.validate_listenbrainz(token, done)
+
+    def _launch_devtools(self, restart=False):
+        self.devtools_status.setText("Restarting Amazon Music…" if restart else "Starting enhanced metadata…")
+
+        def task():
+            return self.coordinator.runtime.launch_enhanced_metadata(restart_if_needed=restart)
+
+        def done(result):
+            self.devtools_status.setText(
+                str(result.get("error") or result.get("detail") or result.get("status") or "Ready")
+            )
+
+        self.coordinator.run_background(task, done, lambda error: self.devtools_status.setText(error))
+
+    def _disable_devtools(self):
+        answer = QMessageBox.question(
+            self,
+            "Reopen Amazon Music normally?",
+            "This closes Amazon Music, removes its local DevTools listener, and reopens it normally. Playback will be interrupted. Continue?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
+        )
+        if answer != QMessageBox.StandardButton.Yes:
+            return
+        self.devtools_status.setText("Reopening Amazon Music without DevTools…")
+
+        def done(result):
+            if result.get("ok"):
+                self.devtools_enabled.setChecked(False)
+                self.devtools_auto.setChecked(False)
+            self.devtools_status.setText(
+                str(
+                    result.get("error")
+                    or result.get("detail")
+                    or result.get("status")
+                    or "Disabled"
+                )
+            )
+
+        self.coordinator.run_background(
+            lambda: self.coordinator.runtime.disable_enhanced_metadata(relaunch=True),
+            done,
+            lambda error: self.devtools_status.setText(error),
+        )
+
+    def export_settings(self):
+        suggested = f"AmazonMusicRPC_Settings_{datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Export Amazon Music RPC settings", str(Path.home() / "Downloads" / suggested), "JSON files (*.json)"
+        )
+        if not path:
+            return
+        try:
+            payload = settings_export_payload(config.load_config(), self.include_secrets.isChecked())
+            _write_private_json(path, payload)
+        except Exception as error:
+            QMessageBox.warning(self, "Export failed", str(error))
+            return
+        self.status.setText(f"Exported to {path}")
+
+    def import_settings(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Import Amazon Music RPC settings", str(Path.home()), "JSON files (*.json)"
+        )
+        if not path:
+            return
+        try:
+            payload = json.loads(Path(path).read_text(encoding="utf-8"))
+            updates = settings_import_updates(payload)
+            if not updates:
+                raise UIValidationError("No recognized settings were found.")
+            saved = config.update_config_fields(updates)
+            config.set_startup(saved.get("start_on_startup"), saved.get("start_minimized"))
+            self.coordinator.runtime_reload(saved)
+            self.load_settings(saved)
+        except Exception as error:
+            QMessageBox.warning(self, "Import failed", str(error))
+            return
+        self.status.setText(f"Imported settings from {path}")
+
+    def apply_snapshot(self, snapshot):
+        devtools = (snapshot or {}).get("amazon_devtools") or {}
+        self.devtools_status.setText(
+            str(devtools.get("detail") or (snapshot or {}).get("devtools_status") or "Waiting")
+        )
+
+    def closeEvent(self, event: QCloseEvent):
+        try:
+            config.update_config_fields(
+                {
+                    "settings_window_width": self.width(),
+                    "settings_window_height": self.height(),
+                }
+            )
+        except Exception:
+            pass
+        super().closeEvent(event)
+
+
+class _StatusCard(QFrame):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("statusCard")
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(15, 13, 15, 14)
+        self.label = QLabel("")
+        self.label.setProperty("muted", True)
+        layout.addWidget(self.label)
+        self.value = QLabel("")
+        self.value.setStyleSheet("font-size: 17px; font-weight: 700;")
+        layout.addWidget(self.value)
+        self.detail = QLabel("")
+        self.detail.setProperty("muted", True)
+        self.detail.setWordWrap(True)
+        layout.addWidget(self.detail)
+
+    def apply(self, label, value, detail):
+        self.label.setText(label)
+        self.value.setText(value.replace("_", " ").title())
+        self.value.setStyleSheet(
+            f"font-size: 17px; font-weight: 700; color: {_status_color(value)};"
+        )
+        self.detail.setText(detail or "—")
+
+
+class DiagnosticsWindow(QMainWindow):
+    def __init__(self, coordinator):
+        super().__init__()
+        self.coordinator = coordinator
+        self.setObjectName("appRoot")
+        self.setStyleSheet(APP_STYLE)
+        self.setWindowTitle(f"{config.APP_DISPLAY_NAME} — Diagnostics")
+        self.setMinimumSize(820, 580)
+        if coordinator.icon:
+            self.setWindowIcon(coordinator.icon)
+        saved = config.load_config()
+        self.resize(
+            max(820, int(saved.get("diagnostics_window_width", 960))),
+            max(580, int(saved.get("diagnostics_window_height", 720))),
+        )
+        self.snapshot = {}
+        self._build()
+        self.refresh()
+
+    def _build(self):
+        central = QWidget()
+        central.setObjectName("appRoot")
+        layout = QVBoxLayout(central)
+        layout.setContentsMargins(22, 18, 22, 18)
+        header = QHBoxLayout()
+        titles = QVBoxLayout()
+        title = QLabel("Diagnostics")
+        title.setProperty("heading", True)
+        titles.addWidget(title)
+        subtitle = QLabel("Live state and redacted troubleshooting data")
+        subtitle.setProperty("muted", True)
+        titles.addWidget(subtitle)
+        header.addLayout(titles)
+        header.addStretch(1)
+        refresh = QPushButton("Refresh")
+        refresh.clicked.connect(self.refresh)
+        header.addWidget(refresh)
+        copy = QPushButton("Copy report")
+        copy.clicked.connect(self.copy_report)
+        header.addWidget(copy)
+        export = QPushButton("Export JSON…")
+        export.setProperty("primary", True)
+        export.clicked.connect(self.export_report)
+        header.addWidget(export)
+        layout.addLayout(header)
+
+        self.tabs = QTabWidget()
+        overview = QWidget()
+        overview.setObjectName("appRoot")
+        overview_layout = QVBoxLayout(overview)
+        overview_layout.setContentsMargins(4, 16, 4, 8)
+        self.cards_layout = QGridLayout()
+        self.cards_layout.setSpacing(10)
+        self.cards = []
+        for index in range(6):
+            card = _StatusCard()
+            self.cards.append(card)
+            self.cards_layout.addWidget(card, index // 3, index % 3)
+        overview_layout.addLayout(self.cards_layout)
+        track = _Card("Current track")
+        self.track_label = QLabel("Waiting for Amazon Music")
+        self.track_label.setStyleSheet("font-size: 16px; font-weight: 700;")
+        self.track_detail = QLabel("")
+        self.track_detail.setProperty("muted", True)
+        self.track_detail.setWordWrap(True)
+        track.layout_box.addWidget(self.track_label)
+        track.layout_box.addWidget(self.track_detail)
+        overview_layout.addWidget(track)
+        paths = _Card("Local files")
+        paths_text = QPlainTextEdit()
+        paths_text.setReadOnly(True)
+        paths_text.setMaximumHeight(125)
+        paths_text.setPlainText(
+            "\n".join(
+                (
+                    f"Config: {config.CONFIG_PATH}",
+                    f"Console: {config.LOG_PATH}",
+                    f"Events: {config.EVENT_LOG_PATH}",
+                    f"Runtime state: {config.DIAGNOSTICS_PATH}",
+                    f"Network: {NETWORK_HISTORY_PATH}",
+                )
+            )
+        )
+        paths.layout_box.addWidget(paths_text)
+        overview_layout.addWidget(paths)
+        overview_layout.addStretch(1)
+        self.tabs.addTab(overview, "Overview")
+
+        network = QWidget()
+        network.setObjectName("appRoot")
+        network_layout = QVBoxLayout(network)
+        network_layout.setContentsMargins(4, 16, 4, 8)
+        self.network_table = QTableWidget(0, 5)
+        self.network_table.setHorizontalHeaderLabels(["Time", "Service", "Operation", "Status", "Detail"])
+        self.network_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        self.network_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        self.network_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
+        self.network_table.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
+        self.network_table.horizontalHeader().setSectionResizeMode(4, QHeaderView.ResizeMode.Stretch)
+        self.network_table.verticalHeader().setVisible(False)
+        self.network_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        network_layout.addWidget(self.network_table)
+        self.tabs.addTab(network, "Network")
+
+        logs = QWidget()
+        logs.setObjectName("appRoot")
+        logs_layout = QVBoxLayout(logs)
+        logs_layout.setContentsMargins(4, 16, 4, 8)
+        self.log_tabs = QTabWidget()
+        self.log_views = {}
+        for label, path in (
+            ("Console", config.LOG_PATH),
+            ("Events", config.EVENT_LOG_PATH),
+            ("Runtime JSON", config.DIAGNOSTICS_PATH),
+        ):
+            view = QPlainTextEdit()
+            view.setReadOnly(True)
+            view.setStyleSheet("font-family: Menlo, Consolas, monospace; font-size: 11px;")
+            self.log_views[path] = view
+            self.log_tabs.addTab(view, label)
+        logs_layout.addWidget(self.log_tabs)
+        self.tabs.addTab(logs, "Logs")
+        layout.addWidget(self.tabs, 1)
+
+        footer = QHBoxLayout()
+        self.status = QLabel("")
+        self.status.setProperty("muted", True)
+        footer.addWidget(self.status, 1)
+        correction = QPushButton("Correct current song")
+        correction.clicked.connect(self.coordinator.show_correction)
+        footer.addWidget(correction)
+        report = QPushButton("Report issue")
+        report.clicked.connect(self.coordinator.report_issue)
+        footer.addWidget(report)
+        layout.addLayout(footer)
+        self.setCentralWidget(central)
+
+    def apply_snapshot(self, snapshot):
+        self.snapshot = dict(snapshot or {})
+        for card, row in zip(self.cards, snapshot_rows(self.snapshot)):
+            card.apply(*row)
+        track = self.snapshot.get("track") or {}
+        self.track_label.setText(track.get("title") or "Waiting for Amazon Music")
+        parts = [track.get("artist"), track.get("album"), self.snapshot.get("time")]
+        parts = [str(part) for part in parts if part]
+        self.track_detail.setText(" • ".join(parts) or str(self.snapshot.get("source_detail") or "No active track"))
+        self.status.setText(f"Updated {datetime.now().strftime('%H:%M:%S')}")
+
+    def refresh(self):
+        self.apply_snapshot(self.coordinator.runtime_snapshot())
+        events = _network_history()
+        self.network_table.setRowCount(0)
+        for event in reversed(events):
+            row = self.network_table.rowCount()
+            self.network_table.insertRow(row)
+            timestamp = event.get("timestamp")
+            try:
+                stamp = datetime.fromtimestamp(float(timestamp)).strftime("%H:%M:%S")
+            except (TypeError, ValueError, OSError):
+                stamp = "—"
+            values = (
+                stamp,
+                event.get("service", ""),
+                event.get("operation", ""),
+                event.get("status", ""),
+                event.get("detail", ""),
+            )
+            for column, value in enumerate(values):
+                self.network_table.setItem(row, column, QTableWidgetItem(str(value or "")))
+        settings = config.load_config()
+        for path, view in self.log_views.items():
+            view.setPlainText(_read_redacted_text(path, settings))
+
+    def report(self):
+        return diagnostic_document(
+            self.coordinator.runtime_snapshot(), config.load_config(), _network_history()
+        )
+
+    def copy_report(self):
+        QApplication.clipboard().setText(json.dumps(self.report(), indent=2, ensure_ascii=False))
+        self.status.setText("Redacted diagnostic report copied to the clipboard.")
+
+    def export_report(self):
+        suggested = f"AmazonMusicRPC_Diagnostics_{datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Export redacted diagnostics", str(Path.home() / "Downloads" / suggested), "JSON files (*.json)"
+        )
+        if not path:
+            return
+        try:
+            _write_private_json(path, self.report())
+        except OSError as error:
+            QMessageBox.warning(self, "Export failed", str(error))
+            return
+        self.status.setText(f"Exported redacted diagnostics to {path}")
+
+    def closeEvent(self, event: QCloseEvent):
+        try:
+            config.update_config_fields(
+                {
+                    "diagnostics_window_width": self.width(),
+                    "diagnostics_window_height": self.height(),
+                }
+            )
+        except Exception:
+            pass
+        super().closeEvent(event)
+
+
+class MacApplicationUI(QObject):
+    """Coordinator exposed to the menu-bar controller and application entrypoint."""
+
+    snapshot_changed = Signal(dict)
+
+    def __init__(
+        self,
+        app=None,
+        runtime=None,
+        icon_path=None,
+        *,
+        on_quit=None,
+        on_open_amazon=None,
+    ):
+        app = app or QApplication.instance()
+        if app is None:
+            raise RuntimeError("Create QApplication before MacApplicationUI")
+        super().__init__()
+        self.app = app
+        self.runtime = runtime
+        self.icon_path = str(icon_path or "")
+        self.icon = QIcon(self.icon_path) if self.icon_path and Path(self.icon_path).is_file() else QIcon()
+        self.on_quit = on_quit
+        self.on_open_amazon = on_open_amazon
+        self.settings_window = None
+        self.diagnostics_window = None
+        self._lastfm_generator = None
+        self._lastfm_auth_url = None
+        self._workers = set()
+        self._suggested_corrections = set()
+        self.thread_pool = QThreadPool.globalInstance()
+        self.snapshot_changed.connect(self._apply_snapshot)
+        if self.runtime and hasattr(self.runtime, "add_listener"):
+            self.runtime.add_listener(self._runtime_listener, emit_current=True)
+
+    @property
+    def callbacks(self):
+        return {
+            "settings": self.show_settings,
+            "diagnostics": self.show_diagnostics,
+            "wrong_song": self.show_guided_correction,
+            "updates": self.check_updates,
+            "launch_amazon": self.open_amazon_music,
+            "quit": self.quit,
+        }
+
+    def _runtime_listener(self, snapshot):
+        self.snapshot_changed.emit(dict(snapshot or {}))
+
+    def _apply_snapshot(self, snapshot):
+        if self.settings_window:
+            self.settings_window.apply_snapshot(snapshot)
+        if self.diagnostics_window:
+            self.diagnostics_window.apply_snapshot(snapshot)
+        raw = snapshot.get("raw_track") or {}
+        key = f"{raw.get('title', '')}|{raw.get('artist', '')}".casefold().strip()
+        if snapshot.get("correction_suggested") and key and key not in self._suggested_corrections:
+            self._suggested_corrections.add(key)
+            QTimer.singleShot(
+                250,
+                lambda value=dict(snapshot): self.show_guided_correction(value),
+            )
+
+    def runtime_snapshot(self):
+        if self.runtime and hasattr(self.runtime, "snapshot"):
+            return self.runtime.snapshot()
+        return {}
+
+    def runtime_reload(self, saved=None):
+        if self.runtime and hasattr(self.runtime, "reload_config"):
+            return self.runtime.reload_config(saved)
+        return saved or config.load_config()
+
+    def show_settings(self):
+        if self.settings_window is None:
+            self.settings_window = SettingsWindow(self)
+            self.settings_window.destroyed.connect(lambda: setattr(self, "settings_window", None))
+        else:
+            self.settings_window.load_settings(config.load_config())
+        self.settings_window.show()
+        self.settings_window.raise_()
+        self.settings_window.activateWindow()
+        return self.settings_window
+
+    def show_diagnostics(self):
+        if self.diagnostics_window is None:
+            self.diagnostics_window = DiagnosticsWindow(self)
+            self.diagnostics_window.destroyed.connect(lambda: setattr(self, "diagnostics_window", None))
+        self.diagnostics_window.refresh()
+        self.diagnostics_window.show()
+        self.diagnostics_window.raise_()
+        self.diagnostics_window.activateWindow()
+        return self.diagnostics_window
+
+    def show_correction(self, snapshot=None):
+        snapshot = snapshot if isinstance(snapshot, dict) else self.runtime_snapshot()
+        raw = snapshot.get("raw_track") or snapshot.get("track") or {}
+        current = snapshot.get("track") or raw
+        if not raw.get("title"):
+            QMessageBox.information(
+                self.diagnostics_window or self.settings_window,
+                "No current song",
+                "Play a song in Amazon Music before correcting metadata.",
+            )
+            return None
+        result = show_correction_dialog(
+            raw,
+            current,
+            icon_path=self.icon_path,
+            parent=self.diagnostics_window or self.settings_window,
+        )
+        if result and result.get("accepted") and self.runtime:
+            remember = bool(result.get("remember"))
+            self.runtime.apply_correction(
+                result.get("raw_title", ""),
+                result.get("raw_artist", ""),
+                result.get("track") or {},
+                remember=remember,
+            )
+            if self.diagnostics_window:
+                detail = (
+                    "Correction remembered for this detected song."
+                    if remember
+                    else "Correction applied for this app session."
+                )
+                self.diagnostics_window.status.setText(detail)
+        return result
+
+    def _apply_picker_result(self, raw, picked, *, remember=False):
+        if not picked or not self.runtime:
+            return None
+        result = self.runtime.apply_correction(
+            raw.get("title", ""),
+            raw.get("artist", ""),
+            picked,
+            remember=remember,
+        )
+        if self.diagnostics_window:
+            self.diagnostics_window.status.setText(
+                "Correction remembered for this detected song."
+                if remember
+                else "Correction applied for this app session."
+            )
+        return result
+
+    def show_guided_correction(self, snapshot=None):
+        """Run the same Wrong Artist/Wrong Song picker flow as Windows."""
+
+        snapshot = snapshot if isinstance(snapshot, dict) else self.runtime_snapshot()
+        raw = snapshot.get("raw_track") or snapshot.get("track") or {}
+        if not raw.get("title"):
+            return self.show_correction(snapshot)
+        parent = self.diagnostics_window or self.settings_window
+        choice = show_wrong_song_dialog(icon_path=self.icon_path, parent=parent).get(
+            "choice"
+        )
+        if not choice:
+            return None
+
+        from Windows.album_art import search_tracks
+
+        if choice == "title":
+            picked = show_input_picker(
+                raw.get("artist", ""),
+                search_fn=search_tracks,
+                icon_path=self.icon_path,
+                parent=parent,
+            )
+            return self._apply_picker_result(raw, picked, remember=False)
+
+        def search():
+            return search_tracks(raw.get("title", ""), limit=5)
+
+        def choose(choices):
+            if not choices:
+                QMessageBox.information(
+                    parent,
+                    "No matches",
+                    "No matching songs were found. You can still use the manual correction fields in Diagnostics.",
+                )
+                return
+            result = show_choice_picker(
+                raw.get("title", ""),
+                choices,
+                search_query=raw.get("title", ""),
+                page_size=5,
+                prompt="Select the correct track:",
+                remember=True,
+                search_fn=search_tracks,
+                icon_path=self.icon_path,
+                parent=parent,
+            )
+            self._apply_picker_result(
+                raw,
+                result.get("track") if result else None,
+                remember=bool(result and result.get("remember")),
+            )
+
+        self.run_background(
+            search,
+            choose,
+            lambda error: QMessageBox.warning(parent, "Search failed", error),
+        )
+        return {"pending": True}
+
+    def run_background(self, function, on_success=None, on_error=None):
+        worker = _Worker(function)
+        self._workers.add(worker)
+
+        def finished(value=None):
+            self._workers.discard(worker)
+            if on_success:
+                on_success(value)
+
+        def failed(error):
+            self._workers.discard(worker)
+            if on_error:
+                on_error(error)
+            else:
+                QMessageBox.warning(self.settings_window, "Operation failed", error)
+
+        worker.signals.succeeded.connect(finished)
+        worker.signals.failed.connect(failed)
+        self.thread_pool.start(worker)
+        return worker
+
+    def validate_listenbrainz(self, token, callback=None):
+        def task():
+            import requests
+
+            response = requests.get(
+                "https://api.listenbrainz.org/1/validate-token",
+                headers={"Authorization": f"Token {token}"},
+                timeout=10,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if payload.get("valid"):
+                return {"valid": True, "user_name": payload.get("user_name", "")}
+            return {"valid": False, "error": "Invalid token. Check it and try again."}
+
+        return self.run_background(
+            task,
+            callback,
+            lambda error: callback({"valid": False, "error": f"Could not validate: {error}"}) if callback else None,
+        )
+
+    def lastfm_auth(self, callback=None):
+        def task():
+            from Windows.lastfm import get_auth_url
+
+            settings = config.load_config()
+            url, generator = get_auth_url(
+                settings.get("lastfm_api_key"), settings.get("lastfm_api_secret")
+            )
+            self._lastfm_generator = generator
+            self._lastfm_auth_url = url
+            webbrowser.open(url)
+            return {"ok": True, "url": url}
+
+        return self.run_background(
+            task,
+            callback,
+            lambda error: callback({"ok": False, "error": error}) if callback else None,
+        )
+
+    def lastfm_complete(self, callback=None):
+        if not self._lastfm_generator or not self._lastfm_auth_url:
+            result = {"ok": False, "error": "Start authentication in the browser first."}
+            if callback:
+                callback(result)
+            return None
+
+        def task():
+            from Windows.lastfm import complete_auth
+
+            session_key, username = complete_auth(self._lastfm_generator, self._lastfm_auth_url)
+            self._lastfm_generator = None
+            self._lastfm_auth_url = None
+            saved = config.update_config_fields(
+                {
+                    "lastfm_session_key": session_key,
+                    "lastfm_username": username,
+                    "lastfm_enabled": True,
+                }
+            )
+            self.runtime_reload(saved)
+            return {"ok": True, "username": username}
+
+        return self.run_background(
+            task,
+            callback,
+            lambda error: callback({"ok": False, "error": error}) if callback else None,
+        )
+
+    def check_updates(self):
+        parent = self.settings_window or self.diagnostics_window
+
+        def task():
+            try:
+                from .updater import check_for_update
+            except ImportError:
+                try:
+                    from updater import check_for_update
+                except ImportError:
+                    return None
+            return check_for_update()
+
+        def done(update):
+            if update is None:
+                QDesktopServices.openUrl(QUrl(RELEASES_URL))
+                return
+            available = bool(getattr(update, "available", False))
+            error = str(getattr(update, "error", "") or "")
+            if not available:
+                QMessageBox.information(
+                    parent,
+                    "Software Update",
+                    f"{config.APP_DISPLAY_NAME} {config.APP_VERSION} is up to date."
+                    if not error
+                    else f"Could not check for updates:\n{error}",
+                )
+                return
+            version = str(getattr(update, "version", "new version") or "new version")
+            changelog = str(getattr(update, "changelog", "") or "")[:1200]
+            choice = QMessageBox.question(
+                parent,
+                "Update available",
+                f"Amazon Music RPC {version} is available.\n\n{changelog}\n\nDownload and open the DMG?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            )
+            if choice != QMessageBox.StandardButton.Yes:
+                return
+            if not getattr(update, "dmg_url", "") or not getattr(update, "expected_sha256", ""):
+                QDesktopServices.openUrl(QUrl(str(getattr(update, "release_url", "") or RELEASES_URL)))
+                return
+            try:
+                from .updater import download_and_open_dmg
+            except ImportError:
+                try:
+                    from updater import download_and_open_dmg
+                except ImportError:
+                    QDesktopServices.openUrl(
+                        QUrl(str(getattr(update, "release_url", "") or RELEASES_URL))
+                    )
+                    return
+            self.run_background(
+                lambda: download_and_open_dmg(update),
+                lambda _result: QMessageBox.information(parent, "Update downloaded", "The update DMG has been opened."),
+            )
+
+        return self.run_background(task, done)
+
+    def report_issue(self):
+        snapshot = self.runtime_snapshot()
+        query = urlencode(
+            {
+                "template": "bug_report.md",
+                "title": "[macOS] ",
+                "body": (
+                    "<!-- Attach the redacted diagnostic JSON from the Diagnostics window. -->\n\n"
+                    f"Version: {config.APP_VERSION}\n"
+                    f"Metadata source: {snapshot.get('source', 'unknown')}\n"
+                ),
+            }
+        )
+        QDesktopServices.openUrl(QUrl(f"{ISSUES_URL}?{query}"))
+
+    def open_amazon_music(self):
+        if self.on_open_amazon:
+            return self.on_open_amazon()
+        return subprocess.Popen(["/usr/bin/open", "-a", "Amazon Music"])
+
+    def quit(self):
+        if self.on_quit:
+            return self.on_quit()
+        if self.runtime and hasattr(self.runtime, "stop"):
+            self.runtime.stop()
+        self.app.quit()
+
+    def shutdown(self):
+        if self.runtime and hasattr(self.runtime, "remove_listener"):
+            self.runtime.remove_listener(self._runtime_listener)
+        for window in (self.settings_window, self.diagnostics_window):
+            if window:
+                window.close()

--- a/MacOS/updater.py
+++ b/MacOS/updater.py
@@ -1,0 +1,320 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+"""Checksum-gated GitHub DMG updater for the macOS build."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from urllib.parse import unquote, urljoin, urlparse
+
+import requests
+
+from . import config
+
+
+REPO = "eripum9/Amazon-Music-Discord-RPC"
+RELEASES_URL = f"https://api.github.com/repos/{REPO}/releases/latest"
+RELEASES_PAGE = f"https://github.com/{REPO}/releases"
+DMG_NAME = "Amazon-Music-RPC.dmg"
+CHECKSUM_NAME = f"{DMG_NAME}.sha256"
+MAX_DMG_BYTES = 500 * 1024 * 1024
+MAX_CHECKSUM_BYTES = 64 * 1024
+MAX_RELEASE_BYTES = 2 * 1024 * 1024
+MAX_REDIRECTS = 5
+REDIRECT_CODES = {301, 302, 303, 307, 308}
+ASSET_REDIRECT_HOSTS = {
+    "release-assets.githubusercontent.com",
+    "objects.githubusercontent.com",
+    "github-releases.githubusercontent.com",
+}
+SHA256_RE = re.compile(r"\b[a-fA-F0-9]{64}\b")
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateInfo:
+    available: bool = False
+    version: str = ""
+    dmg_url: str = ""
+    expected_sha256: str = ""
+    changelog: str = ""
+    release_url: str = RELEASES_PAGE
+    error: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class DownloadedDMG:
+    path: str
+    sha256: str
+    size: int
+    source_url: str
+
+
+def _network_event(operation, status, detail=""):
+    try:
+        from Windows.network_audit import record_network_event
+
+        record_network_event("github", operation, status, detail, config.CONFIG_DIR)
+    except Exception:
+        pass
+
+
+def _version(value):
+    match = re.match(r"^v?(\d+)\.(\d+)\.(\d+)", str(value or "").strip())
+    return tuple(int(part) for part in match.groups()) if match else (0, 0, 0)
+
+
+def _https_url(value):
+    try:
+        parsed = urlparse(str(value or ""))
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme.lower() != "https"
+        or not parsed.hostname
+        or port not in (None, 443)
+        or parsed.username
+        or parsed.password
+        or parsed.fragment
+    ):
+        return None
+    return parsed
+
+
+def _valid_release_api(url, redirected=False):
+    parsed = _https_url(url)
+    return bool(
+        not redirected
+        and parsed
+        and parsed.hostname.lower() == "api.github.com"
+        and parsed.path == f"/repos/{REPO}/releases/latest"
+        and not parsed.query
+    )
+
+
+def _valid_release_page(url):
+    parsed = _https_url(url)
+    if not parsed or parsed.hostname.lower() != "github.com" or parsed.query:
+        return False
+    base = f"/{REPO}/releases"
+    return parsed.path.rstrip("/") == base or parsed.path.startswith(base + "/")
+
+
+def _valid_asset(url, name, redirected=False):
+    parsed = _https_url(url)
+    if not parsed:
+        return False
+    host = parsed.hostname.lower()
+    if redirected:
+        return host in ASSET_REDIRECT_HOSTS and bool(parsed.path and parsed.path != "/")
+    prefix = f"/{REPO}/releases/download/"
+    return bool(
+        host == "github.com"
+        and not parsed.query
+        and parsed.path.startswith(prefix)
+        and unquote(parsed.path.rsplit("/", 1)[-1]) == name
+    )
+
+
+def _bounded_request(url, validator, max_bytes, *, stream=False, request_get=requests.get):
+    current = str(url or "")
+    for redirect_count in range(MAX_REDIRECTS + 1):
+        if not validator(current, redirect_count > 0):
+            raise ValueError("URL is outside the trusted GitHub release boundary")
+        response = request_get(
+            current,
+            timeout=(10, 60) if stream else 10,
+            stream=stream,
+            allow_redirects=False,
+            headers={"Accept": "application/vnd.github+json", "User-Agent": "AmazonMusicRPC-macOS"},
+        )
+        status = int(getattr(response, "status_code", 200) or 200)
+        if status in REDIRECT_CODES:
+            location = (getattr(response, "headers", {}) or {}).get("Location", "")
+            response.close()
+            if not location or redirect_count >= MAX_REDIRECTS:
+                raise ValueError("GitHub release download redirected too many times")
+            current = urljoin(current, location)
+            continue
+        response.raise_for_status()
+        try:
+            length = int((getattr(response, "headers", {}) or {}).get("Content-Length", 0) or 0)
+        except (TypeError, ValueError):
+            length = 0
+        if length > max_bytes:
+            response.close()
+            raise ValueError("GitHub response exceeds the allowed size")
+        return response, current
+    raise ValueError("GitHub release download redirected too many times")
+
+
+def _asset(data, name, maximum):
+    for asset in (data or {}).get("assets", []):
+        if not isinstance(asset, dict) or asset.get("name") != name:
+            continue
+        try:
+            size = int(asset.get("size") or 0)
+        except (TypeError, ValueError):
+            size = 0
+        url = str(asset.get("browser_download_url") or "")
+        if 0 < size <= maximum and _valid_asset(url, name):
+            return asset
+    return {}
+
+
+def _checksum_from_text(value, dmg_name=DMG_NAME):
+    candidates = []
+    for line in str(value or "").splitlines():
+        match = SHA256_RE.search(line)
+        if match:
+            score = int(dmg_name.casefold() in line.casefold()) + int("sha256" in line.casefold())
+            candidates.append((score, match.group(0).lower()))
+    return max(candidates, default=(0, ""))[1]
+
+
+def _release_page(data):
+    candidate = str((data or {}).get("html_url") or "")
+    return candidate if _valid_release_page(candidate) else RELEASES_PAGE
+
+
+def _changelog(body):
+    lines = []
+    for raw in str(body or "").replace("\r", "\n").split("\n"):
+        line = raw.strip().strip("#").strip()
+        if not line or line.startswith(("<!--", "<details", "</details")):
+            continue
+        if line.startswith(("-", "*", "•")):
+            line = "- " + line.lstrip("-*• ")
+        lines.append(line)
+        if len(lines) == 6:
+            break
+    return "\n".join(lines)[:800]
+
+
+def check_for_update(*, request_get=requests.get):
+    try:
+        response, _ = _bounded_request(
+            RELEASES_URL,
+            _valid_release_api,
+            MAX_RELEASE_BYTES,
+            request_get=request_get,
+        )
+        raw = getattr(response, "content", b"") or b""
+        if len(raw) > MAX_RELEASE_BYTES:
+            raise ValueError("GitHub release metadata exceeds the allowed size")
+        data = response.json()
+        response.close()
+        if not isinstance(data, dict) or _version(data.get("tag_name")) == (0, 0, 0):
+            raise ValueError("GitHub release metadata is invalid")
+        if _version(data.get("tag_name")) <= _version(config.APP_VERSION):
+            _network_event("update-check", "success", "up to date")
+            return UpdateInfo(release_url=_release_page(data))
+        dmg = _asset(data, DMG_NAME, MAX_DMG_BYTES)
+        checksum = _asset(data, CHECKSUM_NAME, MAX_CHECKSUM_BYTES)
+        expected = ""
+        if dmg and checksum:
+            checksum_response, _ = _bounded_request(
+                checksum["browser_download_url"],
+                lambda value, redirected: _valid_asset(value, CHECKSUM_NAME, redirected),
+                MAX_CHECKSUM_BYTES,
+                request_get=request_get,
+            )
+            checksum_bytes = getattr(checksum_response, "content", b"") or b""
+            checksum_response.close()
+            if len(checksum_bytes) <= MAX_CHECKSUM_BYTES:
+                expected = _checksum_from_text(checksum_bytes.decode("utf-8", errors="replace"))
+        if not expected:
+            expected = _checksum_from_text(data.get("body"))
+        version = str(data.get("tag_name") or "").lstrip("v")
+        _network_event("update-check", "success", f"v{version} available")
+        return UpdateInfo(
+            available=True,
+            version=version,
+            dmg_url=str(dmg.get("browser_download_url") or ""),
+            expected_sha256=expected,
+            changelog=_changelog(data.get("body")),
+            release_url=_release_page(data),
+        )
+    except Exception as error:
+        detail = f"{type(error).__name__}: {error}"
+        _network_event("update-check", "error", detail)
+        return UpdateInfo(error=detail)
+
+
+def file_sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download_dmg(update, *, request_get=requests.get):
+    if not isinstance(update, UpdateInfo) or not update.available:
+        raise ValueError("An available macOS update is required")
+    expected = str(update.expected_sha256 or "").lower()
+    if not SHA256_RE.fullmatch(expected):
+        raise ValueError("A valid SHA256 checksum is required for automatic download")
+    if not _valid_asset(update.dmg_url, DMG_NAME):
+        raise ValueError("The DMG URL is not a trusted release asset")
+    response, source_url = _bounded_request(
+        update.dmg_url,
+        lambda value, redirected: _valid_asset(value, DMG_NAME, redirected),
+        MAX_DMG_BYTES,
+        stream=True,
+        request_get=request_get,
+    )
+    directory = tempfile.mkdtemp(prefix="AmazonMusicRPC_Update_")
+    path = os.path.join(directory, DMG_NAME)
+    size = 0
+    digest = hashlib.sha256()
+    try:
+        with open(path, "wb") as handle:
+            os.chmod(path, 0o600)
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if not chunk:
+                    continue
+                size += len(chunk)
+                if size > MAX_DMG_BYTES:
+                    raise ValueError("DMG exceeds the download size limit")
+                handle.write(chunk)
+                digest.update(chunk)
+        actual = digest.hexdigest()
+        if actual != expected:
+            raise ValueError(f"DMG checksum mismatch. Expected {expected}, got {actual}.")
+        _network_event("dmg-download", "success", f"{size} bytes")
+        return DownloadedDMG(path, actual, size, source_url)
+    except Exception as error:
+        shutil.rmtree(directory, ignore_errors=True)
+        _network_event("dmg-download", "error", type(error).__name__)
+        raise
+    finally:
+        response.close()
+
+
+def open_dmg(downloaded, *, runner=subprocess.Popen):
+    if not isinstance(downloaded, DownloadedDMG):
+        raise TypeError("DownloadedDMG is required")
+    real_path = os.path.realpath(downloaded.path)
+    temporary_root = os.path.realpath(tempfile.gettempdir())
+    parent = os.path.dirname(real_path)
+    if (
+        os.path.basename(real_path) != DMG_NAME
+        or os.path.dirname(parent) != temporary_root
+        or not os.path.basename(parent).startswith("AmazonMusicRPC_Update_")
+        or file_sha256(real_path) != downloaded.sha256
+    ):
+        raise ValueError("DMG is outside the verified update directory")
+    return runner(["/usr/bin/open", real_path], close_fds=True)
+
+
+def download_and_open_dmg(update, *, request_get=requests.get, runner=subprocess.Popen):
+    downloaded = download_dmg(update, request_get=request_get)
+    open_dmg(downloaded, runner=runner)
+    return downloaded

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amazon Music RPC
 
-Spotify-style Discord Rich Presence for Amazon Music on Windows, with a macOS beta prototype.
+Spotify-style Discord Rich Presence for Amazon Music on Windows and macOS.
 
 Show your Amazon Music songs, album art, pause state, and live timer on Discord.
 
@@ -12,7 +12,7 @@ Show your Amazon Music songs, album art, pause state, and live timer on Discord.
 
 - ✅ Shows current song, artist, album art, and timer on Discord
 - ✅ Lets you display the artist, album, track, or app name after Discord's “Listening to” label
-- ✅ Stable on Amazon Music for Windows; beta prototype for the official Amazon Music macOS app
+- ✅ Stable on Amazon Music for Windows; active beta for the official Amazon Music macOS app
 - ✅ Includes Last.fm and ListenBrainz scrobbling
 - ✅ Privacy mode and keyword filters
 - ✅ No Python needed for the stable Windows installer
@@ -41,7 +41,7 @@ Show your Amazon Music songs, album art, pause state, and live timer on Discord.
 - **Report issue shortcut** — opens the GitHub issue page from Settings or Diagnostics
 - **Auto-updater** — checks for updates on startup and via the Settings window
 - **System tray app** — runs quietly in the background
-- **Modern settings UI** — WebView2 on Windows and a native PySide menu-bar/settings prototype on macOS
+- **Modern settings UI** — WebView2 on Windows and a native PySide menu-bar/settings experience on macOS
 - **Start at login** — optional Windows startup entry or per-user macOS LaunchAgent
 - **Custom Discord Application ID** — use your own if you want custom assets
 - **Network controls** — independently control automatic update checks, Deezer lookup, and iTunes artwork fallback
@@ -59,7 +59,7 @@ If enhanced Amazon metadata is unavailable, the app falls back to Windows' Syste
 
 ### macOS beta
 
-The official Amazon Music app is available on macOS. The beta uses a validated Chromium DevTools target as its primary metadata source because it provides the richest title, artist, album, artwork, playback-state, link, and timing data. If Amazon Music is already running normally when enhanced metadata is first enabled, the user must explicitly approve a one-time restart so Amazon Music can reopen with its loopback debugging flag. The beta does not modify the Amazon Music bundle or its account files.
+macOS is an active development target maintained alongside Windows on `master`. The official Amazon Music app is available on macOS, and the beta uses a validated Chromium DevTools target as its primary metadata source because it provides the richest title, artist, album, artwork, playback-state, link, and timing data. If Amazon Music is already running normally when enhanced metadata is first enabled, the user must explicitly approve a one-time restart so Amazon Music can reopen with its loopback debugging flag. The beta does not modify the Amazon Music bundle or its account files.
 
 When DevTools metadata is disabled or unavailable, the beta falls back to the local macOS Now Playing state and accepts data only when the owning bundle identifier is `com.amazon.music`. The fallback is read-only and does not control playback. See [the macOS beta guide](docs/macos-beta.md) and [the integration research](docs/macos-integration-research.md).
 
@@ -146,7 +146,7 @@ Official installers are created only by the manually triggered **Build Draft Rel
 
 ### macOS beta DMG
 
-The macOS prototype produces `Amazon-Music-RPC.dmg` with `Amazon Music RPC.app` and an Applications shortcut. Mount the DMG, drag the app onto **Applications**, eject the DMG, and launch the installed copy. This is currently a beta development artifact, not the stable release linked above. This repository does not claim that a published macOS artifact has been Developer ID signed or notarized; verify the provenance of any DMG before opening it.
+The macOS build tooling produces `Amazon-Music-RPC.dmg` with `Amazon Music RPC.app` and an Applications shortcut. Mount the DMG, drag the app onto **Applications**, eject the DMG, and launch the installed copy. This is currently a local beta development artifact, not a published release. The v5.0.1 release remains Windows-only and does not include a macOS DMG. This repository does not claim that a macOS artifact has been Developer ID signed or notarized; verify the provenance of any DMG before opening it.
 
 ### Windows from source
 
@@ -162,7 +162,7 @@ python Windows/main.py
 ```bash
 git clone https://github.com/eripum9/Amazon-Music-Discord-RPC.git
 cd Amazon-Music-Discord-RPC
-git checkout beta/MacOS
+git checkout master
 python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install -r MacOS/requirements.txt
@@ -182,13 +182,13 @@ No Python installation is needed when using the stable Windows installer.
 ## Platform Status
 
 - Windows is the stable supported platform on `master`.
-- macOS is an experimental beta prototype on `beta/MacOS`, enabled by Amazon's official macOS desktop app. It is not yet a stable release.
+- macOS is an active beta target maintained on `master`, enabled by Amazon's official macOS desktop app and tested in macOS CI. It is not yet a published stable release.
 - Android support has been discontinued because the mobile integration was too unstable to support responsibly.
 - Linux remains out of scope because it has no official Amazon Music desktop app surface suitable for this integration. Supported platform scope is tracked in [docs/platform-roadmap.md](docs/platform-roadmap.md).
 
 ## Building
 
-Windows app source, dependencies, icons, and packaging files live in `Windows/`. The macOS beta lives in `MacOS/`; platform-neutral playback rules live in `Shared/` and must remain behaviorally identical across both builds.
+Windows app source, dependencies, icons, and packaging files live in `Windows/`. The active macOS beta lives in `MacOS/`; platform-neutral playback rules live in `Shared/` and must remain behaviorally identical across both builds.
 
 The commands below create local development builds. They are not official release artifacts. Official releases must use the manual GitHub Actions workflow described in [docs/release-process.md](docs/release-process.md).
 
@@ -235,7 +235,7 @@ MacOS/scripts/build_app.sh
 MacOS/scripts/create_dmg.sh
 ```
 
-Outputs are `MacOS/dist/Amazon Music RPC.app`, `MacOS/dist/Amazon-Music-RPC.dmg`, and its `.sha256` file. The build architecture follows the selected Python environment. Without a configured Developer ID identity the script creates an ad-hoc-signed local prototype; it is not a notarized distribution. See [MacOS/PERMISSIONS.md](MacOS/PERMISSIONS.md) for the separate release-signing workflow and limitations.
+Outputs are `MacOS/dist/Amazon Music RPC.app`, `MacOS/dist/Amazon-Music-RPC.dmg`, and its `.sha256` file. The build architecture follows the selected Python environment. Without a configured Developer ID identity the script creates an ad-hoc-signed local beta build; it is not a notarized distribution or official release. See [MacOS/PERMISSIONS.md](MacOS/PERMISSIONS.md) for the separate release-signing workflow and limitations.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # Amazon Music RPC
 
-Spotify-style Discord Rich Presence for Amazon Music on Windows.
+Spotify-style Discord Rich Presence for Amazon Music on Windows, with a macOS beta prototype.
 
 Show your Amazon Music songs, album art, pause state, and live timer on Discord.
 
-![Windows](https://img.shields.io/badge/platform-Windows%2010%2F11-blue)
+![Windows stable](https://img.shields.io/badge/Windows-stable-blue)
+![macOS beta](https://img.shields.io/badge/macOS-beta-orange)
 ![Python](https://img.shields.io/badge/python-3.11%2B-yellow)
 
-[Download for Windows](https://github.com/eripum9/Amazon-Music-Discord-RPC/releases/latest) · [View Demo](https://eripum9.github.io/Amazon-Music-Discord-RPC/#demo) · [Troubleshooting](https://eripum9.github.io/Amazon-Music-Discord-RPC/wiki/troubleshooting/) · [Privacy & Security](https://eripum9.github.io/Amazon-Music-Discord-RPC/wiki/privacy/)
+[Download stable Windows release](https://github.com/eripum9/Amazon-Music-Discord-RPC/releases/latest) · [macOS beta guide](docs/macos-beta.md) · [View Demo](https://eripum9.github.io/Amazon-Music-Discord-RPC/#demo) · [Troubleshooting](https://eripum9.github.io/Amazon-Music-Discord-RPC/wiki/troubleshooting/) · [Privacy & Security](https://eripum9.github.io/Amazon-Music-Discord-RPC/wiki/privacy/)
 
 - ✅ Shows current song, artist, album art, and timer on Discord
 - ✅ Lets you display the artist, album, track, or app name after Discord's “Listening to” label
-- ✅ Works with Amazon Music for Windows
+- ✅ Stable on Amazon Music for Windows; beta prototype for the official Amazon Music macOS app
 - ✅ Includes Last.fm and ListenBrainz scrobbling
 - ✅ Privacy mode and keyword filters
-- ✅ No Python needed — download the installer
+- ✅ No Python needed for the stable Windows installer
 
 ## Preview
 
@@ -30,7 +31,7 @@ Show your Amazon Music songs, album art, pause state, and live timer on Discord.
 
 - **Live track display** — title, artist, album name, and progress bar with elapsed/total time
 - **Album art** — uses Amazon Music artwork first, with external artwork lookup as fallback
-- **Fallback metadata** — uses SMTC and Windows notifications only when enhanced Amazon metadata is unavailable
+- **Fallback metadata** — uses Windows SMTC/optional notifications or the macOS Now Playing state when enhanced metadata is unavailable
 - **Pause state** — keeps your presence visible when paused, with a frozen progress bar and pause icon
 - **Last.fm scrobbling** — authenticate with one click and scrobble tracks automatically
 - **ListenBrainz scrobbling** — paste your user token, validate it in Settings, and scrobble tracks
@@ -40,13 +41,15 @@ Show your Amazon Music songs, album art, pause state, and live timer on Discord.
 - **Report issue shortcut** — opens the GitHub issue page from Settings or Diagnostics
 - **Auto-updater** — checks for updates on startup and via the Settings window
 - **System tray app** — runs quietly in the background
-- **Modern settings UI** — dark theme with WebView2 (Edge), Windows 11 style, with saved window sizing
-- **Start on Windows startup** — optional, launches minimized to tray
+- **Modern settings UI** — WebView2 on Windows and a native PySide menu-bar/settings prototype on macOS
+- **Start at login** — optional Windows startup entry or per-user macOS LaunchAgent
 - **Custom Discord Application ID** — use your own if you want custom assets
 - **Network controls** — independently control automatic update checks, Deezer lookup, and iTunes artwork fallback
 - **Request transparency** — review recent redacted outbound request status in Diagnostics
 
 ## How It Works
+
+### Windows stable
 
 Amazon Music metadata is read from the local Amazon Music desktop app when enhanced metadata is enabled. This provides the current title, artist, album, artwork, playback state, and progress timing for Discord Rich Presence.
 
@@ -54,19 +57,31 @@ Amazon Music metadata is read from the local Amazon Music desktop app when enhan
 
 If enhanced Amazon metadata is unavailable, the app falls back to Windows' System Media Transport Controls (SMTC). Notification fallback can optionally enrich that fallback path with artist and album metadata from Amazon Music's Windows notifications.
 
+### macOS beta
+
+The official Amazon Music app is available on macOS. The beta uses a validated Chromium DevTools target as its primary metadata source because it provides the richest title, artist, album, artwork, playback-state, link, and timing data. If Amazon Music is already running normally when enhanced metadata is first enabled, the user must explicitly approve a one-time restart so Amazon Music can reopen with its loopback debugging flag. The beta does not modify the Amazon Music bundle or its account files.
+
+When DevTools metadata is disabled or unavailable, the beta falls back to the local macOS Now Playing state and accepts data only when the owning bundle identifier is `com.amazon.music`. The fallback is read-only and does not control playback. See [the macOS beta guide](docs/macos-beta.md) and [the integration research](docs/macos-integration-research.md).
+
 ## Security & Privacy
 
 Amazon Music RPC is not affiliated with Amazon, Discord, Last.fm, ListenBrainz, Deezer, or Apple.
 
-Enhanced metadata is optional for new installs. When enabled, the app launches or repairs the Microsoft Store version of Amazon Music with a local debugging interface so it can read the current Amazon Music page directly. This gives better title, album, artwork, pause state, and timing data than Windows fallback metadata. The debug port is picked randomly from a high local port range for each app session, kept in memory, and the app only attaches to Amazon Music targets on `music.amazon.*`.
+On Windows, enhanced metadata is optional for new installs. When enabled, the app launches or repairs the Microsoft Store version of Amazon Music with a local debugging interface so it can read the current Amazon Music page directly. This gives better title, album, artwork, pause state, and timing data than Windows fallback metadata. The debug port is picked randomly from a high local port range for each app session, kept in memory, and the app only attaches to Amazon Music targets on `music.amazon.*`.
 
-Fallback-only mode is available in Settings by turning off **Enhanced Amazon metadata**. In fallback-only mode, the app uses Windows media metadata and optional notification enrichment instead of the Amazon Music debug interface.
+On macOS, the beta accepts only the official `/Applications/Amazon Music.app` bundle with identifier `com.amazon.music` and Amazon's signing identity. It connects to a random port in `49152–60999` on `127.0.0.1`, verifies that every listener belongs to that installation, and evaluates only a bounded read-only transport-metadata script in an exact Amazon Music HTTPS page target. It does not request cookies, browser storage, network headers, account files, or debugger attachment. The CEF debugging endpoint itself has no application-level authentication, so another process running as the same local user could potentially connect while it is enabled; closing Amazon Music or relaunching it normally removes that endpoint.
+
+Fallback-only mode is available in Settings by turning off **Enhanced Amazon metadata**. Windows then uses SMTC and optional notification enrichment; macOS uses the owner-validated Now Playing reader. Turning off the macOS checkbox stops Amazon Music RPC from connecting, but it cannot remove a listener already owned by the running Amazon app. Use **Disable listener & reopen normally** (with explicit confirmation), or close and reopen Amazon Music normally, to remove that listener.
 
 Notification enrichment is off by default. If enabled, Windows may ask for notification access. The app reads notifications locally and only uses Amazon Music notifications to improve fallback metadata.
 
 Private session mode clears Discord presence and can stop scrobbling while it is enabled. Keyword privacy rules can also block specific tracks from being shared.
 
 Settings are stored in `%APPDATA%\AmazonMusicRPC\config.json` for installed builds, or the `Windows/` directory when running from source. Last.fm and ListenBrainz tokens are stored in Windows Credential Manager. If Credential Manager is unavailable, the app keeps a DPAPI-protected fallback file and verifies it before removing any previous copy. Diagnostics and log views redact known token values, and Settings includes a clear-token action.
+
+The macOS beta stores non-secret settings and redacted diagnostics under `~/Library/Application Support/AmazonMusicRPC/`. Last.fm and ListenBrainz secrets are generic-password items in the login Keychain under service `io.github.eripum9.amazon-music-rpc`; they are not written to `config.json`. An optional start-at-login setting writes `~/Library/LaunchAgents/io.github.eripum9.amazon-music-rpc.plist`.
+
+Normal macOS operation is not expected to require Accessibility, Automation, Screen Recording, Input Monitoring, Full Disk Access, Media & Apple Music, or Local Network permission. Keychain access, a background-item notice after enabling start at login, and access to a location explicitly selected in an import/export file picker are conditional. See [MacOS/PERMISSIONS.md](MacOS/PERMISSIONS.md) for the complete permission boundary.
 
 Optional outbound services are individually configurable under **Network & Updates**. Automatic update checks contact GitHub, Deezer lookups can receive track and artist search text, and iTunes can receive the same search text when used as an artwork fallback. Diagnostics records a bounded, redacted history containing the service, operation, result, and time, but not the search query or token value. See [docs/network-endpoints.md](docs/network-endpoints.md) for the complete endpoint inventory.
 
@@ -78,6 +93,7 @@ Optional outbound services are individually configurable under **Network & Updat
 | Album art URL | Discord Rich Presence artwork | Discord IPC |
 | Amazon Music page metadata | Enhanced metadata | Local only |
 | Windows SMTC metadata | Fallback metadata | Local only until shown in Discord |
+| macOS Now Playing metadata | macOS fallback metadata | Local only until shown in Discord |
 | Amazon Music notifications | Optional fallback enrichment | Local only until shown in Discord |
 | Last.fm session key | Optional scrobbling | Last.fm |
 | ListenBrainz token | Optional scrobbling | ListenBrainz |
@@ -90,12 +106,14 @@ To run without enhanced metadata:
 
 1. Open **Settings** from the tray icon.
 2. Turn off **Enhanced Amazon metadata**.
-3. Leave **Notification enrichment** off if you also want to avoid Windows notification access.
+3. On Windows, leave **Notification enrichment** off if you also want to avoid Windows notification access. macOS does not use notification enrichment.
 4. Turn off Last.fm and ListenBrainz if you do not want scrobbling.
 
 ### Uninstall
 
 The installer removes the app startup entry, installed files, app config directory, logs, and Amazon Music metadata launcher shortcuts during uninstall. If you ran from source, delete the project folder, the `Windows/config.json` source config if present, and `%APPDATA%\AmazonMusicRPC` manually.
+
+For the macOS beta, quit the menu-bar app, remove `Amazon Music RPC.app` from Applications, and remove `~/Library/Application Support/AmazonMusicRPC` if you also want to delete settings and logs. Remove `~/Library/LaunchAgents/io.github.eripum9.amazon-music-rpc.plist` if start at login was enabled. Scrobbler credentials can be removed from Keychain Access by deleting generic-password items for service `io.github.eripum9.amazon-music-rpc`.
 
 For vulnerability reporting and supported version details, see [SECURITY.md](SECURITY.md).
 
@@ -103,7 +121,7 @@ For implementation boundaries and maintainability details, see [docs/architectur
 
 ## Installation
 
-### Installer (recommended)
+### Windows installer (recommended stable release)
 
 Download `AmazonMusicRPC_Setup.exe` from [Releases](../../releases), run it, and you're done. The installer:
 
@@ -112,7 +130,7 @@ Download `AmazonMusicRPC_Setup.exe` from [Releases](../../releases), run it, and
 - Optionally adds a startup entry
 - Shows up in **Settings > Apps** for clean uninstall
 
-### Release Verification
+### Windows release verification
 
 Releases include `AmazonMusicRPC_Setup.exe.sha256` beside the installer. The built-in updater opens the GitHub release page before running an installer and verifies the installer against that checksum asset. Older releases with a SHA256 value in their release notes remain supported.
 
@@ -126,7 +144,11 @@ Compare the output with the value in `AmazonMusicRPC_Setup.exe.sha256` on the Gi
 
 Official installers are created only by the manually triggered **Build Draft Release** GitHub Actions workflow from the current `master` commit. The workflow runs tests, audits dependencies, builds from a hash-locked environment, creates provenance attestations, and leaves the release as a draft for maintainer review. Maintainer steps are documented in [docs/release-process.md](docs/release-process.md) and [docs/release-checklist.md](docs/release-checklist.md).
 
-### From Source
+### macOS beta DMG
+
+The macOS prototype produces `Amazon-Music-RPC.dmg` with `Amazon Music RPC.app` and an Applications shortcut. Mount the DMG, drag the app onto **Applications**, eject the DMG, and launch the installed copy. This is currently a beta development artifact, not the stable release linked above. This repository does not claim that a published macOS artifact has been Developer ID signed or notarized; verify the provenance of any DMG before opening it.
+
+### Windows from source
 
 ```bash
 git clone https://github.com/eripum9/Amazon-Music-Discord-RPC.git
@@ -135,23 +157,38 @@ pip install -r Windows/requirements.txt
 python Windows/main.py
 ```
 
+### macOS beta from source
+
+```bash
+git clone https://github.com/eripum9/Amazon-Music-Discord-RPC.git
+cd Amazon-Music-Discord-RPC
+git checkout beta/MacOS
+python3.12 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r MacOS/requirements.txt
+python -m MacOS.main
+```
+
+The macOS runtime and automated tests are implemented, but live Discord Rich Presence and live Last.fm/ListenBrainz scrobbling still require manual verification. Discord was not installed on the first development machine, so passing mocked connectivity tests must not be treated as an end-to-end result.
+
 ## Requirements
 
-- **Windows 10/11** (64-bit)
-- **Amazon Music for Windows**. The Microsoft Store version is recommended for enhanced metadata.
+- **Windows stable:** Windows 10/11 (64-bit) and Amazon Music for Windows. The Microsoft Store version is recommended for enhanced metadata.
+- **macOS beta:** macOS 12 or later is the declared build target, the official Amazon Music app installed at `/Applications/Amazon Music.app`, and a build matching the Mac's processor architecture. Initial development was on Intel macOS 15.7.7; broader OS and Apple-silicon testing is still required.
 - **Discord** desktop app (running)
 
-No Python installation needed if using the Installer.
+No Python installation is needed when using the stable Windows installer.
 
 ## Platform Status
 
-- Windows is the stable supported platform.
+- Windows is the stable supported platform on `master`.
+- macOS is an experimental beta prototype on `beta/MacOS`, enabled by Amazon's official macOS desktop app. It is not yet a stable release.
 - Android support has been discontinued because the mobile integration was too unstable to support responsibly.
-- Linux and macOS are out of scope because Amazon Music does not provide official desktop apps for those platforms. Supported platform scope is tracked in [docs/platform-roadmap.md](docs/platform-roadmap.md).
+- Linux remains out of scope because it has no official Amazon Music desktop app surface suitable for this integration. Supported platform scope is tracked in [docs/platform-roadmap.md](docs/platform-roadmap.md).
 
 ## Building
 
-Windows app source, dependencies, icons, and packaging files live in `Windows/`.
+Windows app source, dependencies, icons, and packaging files live in `Windows/`. The macOS beta lives in `MacOS/`; platform-neutral playback rules live in `Shared/` and must remain behaviorally identical across both builds.
 
 The commands below create local development builds. They are not official release artifacts. Official releases must use the manual GitHub Actions workflow described in [docs/release-process.md](docs/release-process.md).
 
@@ -186,11 +223,27 @@ You can also run the Windows build script:
 Windows\build.bat
 ```
 
+### Build the macOS beta app and DMG
+
+On macOS with Python 3.12 and Xcode command-line tools:
+
+```bash
+python3.12 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r MacOS/requirements-build.txt
+MacOS/scripts/build_app.sh
+MacOS/scripts/create_dmg.sh
+```
+
+Outputs are `MacOS/dist/Amazon Music RPC.app`, `MacOS/dist/Amazon-Music-RPC.dmg`, and its `.sha256` file. The build architecture follows the selected Python environment. Without a configured Developer ID identity the script creates an ad-hoc-signed local prototype; it is not a notarized distribution. See [MacOS/PERMISSIONS.md](MacOS/PERMISSIONS.md) for the separate release-signing workflow and limitations.
+
 ## Configuration
 
 Settings are stored in `%APPDATA%\AmazonMusicRPC\config.json` (or the `Windows/` directory when running from source).
 
-Right-click the tray icon and select **Settings** to open the configuration window.
+On macOS, non-secret settings are stored in `~/Library/Application Support/AmazonMusicRPC/config.json`, while scrobbler secrets use the login Keychain service described above.
+
+On Windows, right-click the tray icon and select **Settings**. On macOS, use **Settings** from the menu-bar item.
 
 Under **Startup & Presence**, the **Discord status display** setting controls what follows Discord's "Listening to" label. Choose Artist (the default), Album, Track, or Amazon Music. Album mode falls back to the artist when album metadata is unavailable.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,10 +17,11 @@ For sensitive reports, use [GitHub private vulnerability reporting](https://gith
 Useful report details:
 
 - Amazon Music RPC version
-- Windows version
-- Whether the installed build or source build is used
+- Platform and OS version
+- Whether the Windows installer, macOS beta DMG, or source build is used
+- Amazon Music app version and installation source
 - Whether enhanced metadata is enabled
-- Whether notification enrichment or scrobbling is enabled
+- Whether fallback metadata, Windows notification enrichment, or scrobbling is enabled
 - A short reproduction path
 - Redacted logs only
 
@@ -31,10 +32,16 @@ Amazon Music RPC can read:
 - Amazon Music playback metadata from the local Amazon Music app when enhanced metadata is enabled
 - Windows media metadata through SMTC fallback
 - Amazon Music Windows notifications when notification enrichment is enabled
+- The local macOS Now Playing object when the active owner is exactly
+  `com.amazon.music`
 - Settings from the local config file
 - Local logs for the diagnostics window
 
-Enhanced metadata uses a local debugging interface on a random high port for the current app session. The selected port is kept in memory, shared only with child settings windows, and target validation is limited to Amazon Music pages on `music.amazon.*`.
+Enhanced metadata uses a local debugging interface on a random high port. On
+macOS the selected port is kept in memory and can be rediscovered after an RPC
+restart only from a loopback listener owned by a validated official Amazon Music
+process with an accepted Amazon page target. The integration does not read
+Amazon browser profiles, cookies, storage, account files, or request headers.
 
 Notification enrichment is disabled by default. If enabled, it reads Windows notifications locally and filters them for Amazon Music metadata.
 
@@ -54,7 +61,16 @@ Automatic update checks, Deezer lookup, and iTunes artwork fallback can each be 
 
 ## Tokens And Secrets
 
-Last.fm session keys and ListenBrainz tokens are stored locally when those features are enabled. Sensitive config values are migrated out of `%APPDATA%\AmazonMusicRPC\config.json` into Windows Credential Manager. Migration verifies each stored value before removing its previous copy. If Credential Manager is unavailable, a DPAPI-wrapped local secret file remains as fallback. Diagnostics and log views redact known token values, Settings exports omit tokens unless explicitly requested, and Settings includes a clear-token action. Local app data should still be treated as private because a running app needs decrypted values in memory.
+Last.fm session keys and ListenBrainz tokens are stored locally when those
+features are enabled. On Windows, sensitive config values are migrated out of
+`%APPDATA%\AmazonMusicRPC\config.json` into Windows Credential Manager; a
+DPAPI-wrapped local secret file is the compatibility fallback. On macOS,
+scrobbler secrets are generic-password items in the login Keychain under service
+`io.github.eripum9.amazon-music-rpc` and are omitted from
+`~/Library/Application Support/AmazonMusicRPC/config.json`. Diagnostics and log
+views redact known token values, and normal Settings exports omit tokens unless
+explicitly requested. Local app data should still be treated as private because
+a running app needs decrypted values in memory.
 
 Do not paste config files, diagnostics, or logs publicly unless you have checked that tokens and private data are removed.
 
@@ -74,9 +90,33 @@ Security behavior:
 - The common DevTools port `9222` is not used for launching Amazon Music.
 - Diagnostics warns if the common DevTools port is reachable unexpectedly.
 
+The macOS beta additionally requires the standard
+`/Applications/Amazon Music.app` location, expected `com.amazon.music` bundle
+identifier and executable, and Amazon's expected signing identity. Listener
+process executables must resolve inside that installation. It accepts only
+loopback ports in its private high-port range and an exact supported Amazon
+Music HTTPS page (including the exact legacy Morpho web-app path), then performs
+a bounded read-only transport-metadata evaluation. Listener ownership is
+rechecked around discovery/evaluation.
+
+The Amazon CEF endpoint itself has no application-level authentication. Another
+process already running as the same local user may be able to discover and use
+it while enhanced metadata is active. Binding to loopback prevents access from
+another device; it does not isolate same-user software.
+
 When Amazify integration is present, its localhost bridge requires a per-user random token and accepts browser requests only from exact supported Amazon Music origins. Uninstall removes only the Amazon Music RPC integration files and token.
 
-To disable enhanced metadata, open Settings and turn off **Enhanced Amazon metadata**. To avoid Windows notification access too, leave **Notification enrichment** turned off.
+To stop Amazon Music RPC from attaching, open Settings and turn off **Enhanced
+Amazon metadata**. On macOS, that checkbox cannot remove a listener already
+owned by a running Amazon Music process. Use the explicit action to disable
+enhanced metadata and relaunch Amazon Music normally, close Amazon Music, or
+relaunch it normally yourself to remove the listener; this is never done as a
+silent fallback. To avoid Windows notification access too, leave
+**Notification enrichment** turned off.
+
+The macOS app's own local IPC is an owner-only Unix-domain socket used only for
+single-instance commands. It accepts a fixed command allowlist and does not
+listen on TCP or a non-loopback network interface.
 
 ## Private Session
 
@@ -84,11 +124,27 @@ Private session mode clears Discord Rich Presence and can stop scrobbling while 
 
 ## Updates
 
-The updater checks GitHub releases and can download the latest installer. It opens the GitHub release page before running the installer, requires an `AmazonMusicRPC_Setup.exe.sha256` release asset or a legacy SHA256 hash in the release notes, downloads to a unique temporary directory, and verifies the installer before launching it. If no hash is available, automatic install is disabled and the app only opens the release page.
+The Windows updater checks GitHub releases and can download the latest
+installer. It opens the GitHub release page before running the installer,
+requires an `AmazonMusicRPC_Setup.exe.sha256` release asset or a legacy SHA256
+hash in the release notes, downloads to a unique temporary directory, and
+verifies the installer before launching it. If no hash is available, automatic
+install is disabled and the app only opens the release page.
+
+The macOS beta updater accepts only the exact `Amazon-Music-RPC.dmg` asset from
+the configured repository and approved GitHub asset redirects. Automatic
+download requires a valid SHA256 from the matching checksum asset or release
+notes, enforces response-size limits, verifies the downloaded bytes in a unique
+temporary directory, and opens the DMG for an explicit drag install. It does not
+silently overwrite the installed application.
 
 Official release drafts are built only from the current `master` commit by a manually triggered GitHub Actions workflow. The workflow installs hash-locked dependencies, runs tests and dependency auditing, creates an SBOM and build evidence, scans the installer with Microsoft Defender when available, and generates GitHub artifact attestations. Each release includes `AmazonMusicRPC_Setup.exe`, its matching `AmazonMusicRPC_Setup.exe.sha256`, a clear changelog, and an enhanced metadata compatibility note.
 
-Windows artifacts are not Authenticode signed. Verify the matching SHA256 asset and GitHub build provenance attestation before running an installer.
+Windows artifacts are not Authenticode signed. Verify the matching SHA256 asset
+and GitHub build provenance attestation before running an installer. A local
+macOS beta build is ad-hoc signed unless a release operator performs the
+documented Developer ID signing and notarization workflow; do not treat an
+ad-hoc DMG as a public release.
 
 ## Uninstall
 

--- a/Shared/__init__.py
+++ b/Shared/__init__.py
@@ -1,0 +1,3 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+"""Platform-neutral behavior shared by the Windows and macOS runtimes."""

--- a/Shared/playback.py
+++ b/Shared/playback.py
@@ -1,0 +1,270 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+"""Pure playback rules used by every desktop runtime.
+
+This module intentionally contains no UI, network, process-enumeration, or
+credential code.  Keeping the decisions here platform neutral makes the
+Windows and macOS builds agree on privacy, corrections, game mode, and
+scrobble thresholds while allowing each runtime to supply native metadata.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Mapping
+
+
+TEXT_LIMIT = 512
+URL_LIMIT = 4096
+SCROBBLE_MINIMUM_SECONDS = 30.0
+SCROBBLE_HALF_DURATION = 0.5
+SCROBBLE_FALLBACK_SECONDS = 240.0
+
+
+def normalised_text(value):
+    """Return case-insensitive, whitespace-stable text for comparisons."""
+
+    return " ".join(str(value or "").strip().casefold().split())
+
+
+def same_track_field(left, right):
+    left = normalised_text(left)
+    right = normalised_text(right)
+    return bool(left and right and left == right)
+
+
+def duration_value(value):
+    """Return a non-negative whole-second duration for external APIs."""
+
+    try:
+        return max(0, int(float(value or 0)))
+    except (OverflowError, TypeError, ValueError):
+        return 0
+
+
+def nonnegative_number(value, default=0.0):
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0.0, number) if math.isfinite(number) else default
+
+
+def normalise_track(track, source=""):
+    """Convert a native metadata mapping to the common playback shape."""
+
+    if not isinstance(track, Mapping):
+        return None
+    title = str(track.get("title") or "").strip()[:TEXT_LIMIT]
+    if not title:
+        return None
+    artist = str(track.get("artist") or "").strip()[:TEXT_LIMIT]
+    status = str(track.get("status") or "").strip().casefold()
+    if status not in {"playing", "paused"}:
+        status = str(track.get("playback_status") or "playing").strip().casefold()
+    if status not in {"playing", "paused"}:
+        status = "playing"
+
+    position = track.get("position")
+    try:
+        position = max(0.0, float(position)) if position is not None else None
+    except (TypeError, ValueError):
+        position = None
+    duration = nonnegative_number(track.get("duration"))
+    if position is not None and duration:
+        position = min(position, duration)
+
+    return {
+        "title": title,
+        "artist": artist,
+        "album": str(track.get("album") or "").strip()[:TEXT_LIMIT],
+        "status": status,
+        "position": position,
+        "duration": duration,
+        "art_url": str(track.get("art_url") or track.get("_amazon_art_url") or "").strip()[:URL_LIMIT],
+        "track_link": str(track.get("track_link") or track.get("_amazon_track_link") or "").strip()[:URL_LIMIT],
+        "source": str(track.get("source") or source or "unknown").strip()[:80],
+    }
+
+
+def track_info_payload(track):
+    track = track if isinstance(track, Mapping) else {}
+    return {
+        "title": track.get("title", ""),
+        "artist": track.get("artist", ""),
+        "album": track.get("album", ""),
+        "art_url": track.get("art_url", ""),
+        "track_link": track.get("track_link", ""),
+        "duration": duration_value(track.get("duration", 0)),
+    }
+
+
+def privacy_keywords(config_or_value):
+    if isinstance(config_or_value, Mapping):
+        raw = config_or_value.get("privacy_blocked_keywords", "")
+    else:
+        raw = config_or_value
+    items = raw if isinstance(raw, (list, tuple, set)) else str(raw or "").replace("\n", ",").split(",")
+    return [normalised_text(item) for item in items if normalised_text(item)]
+
+
+def privacy_match(config, title="", artist="", album=""):
+    config = config if isinstance(config, Mapping) else {}
+    if config.get("privacy_private_session"):
+        return "Private session enabled"
+    haystack = normalised_text(f"{title} {artist} {album}")
+    for keyword in privacy_keywords(config):
+        if keyword in haystack:
+            return f"Matched privacy keyword: {keyword}"
+    return ""
+
+
+def privacy_reason(config, track):
+    track = track if isinstance(track, Mapping) else {}
+    return privacy_match(
+        config,
+        track.get("title", ""),
+        track.get("artist", ""),
+        track.get("album", ""),
+    )
+
+
+def normalise_process_name(value):
+    """Normalise either Windows or POSIX executable paths on any host OS."""
+
+    text = str(value or "").strip().strip('"').strip("'").replace("\\", "/")
+    return text.rsplit("/", 1)[-1].casefold()
+
+
+def configured_game_mode_processes(config_or_value):
+    if isinstance(config_or_value, Mapping):
+        value = config_or_value.get("game_mode_processes", "")
+    else:
+        value = config_or_value
+    parts = value if isinstance(value, (list, tuple, set)) else str(value or "").replace(";", ",").replace("\n", ",").split(",")
+    return {name for name in (normalise_process_name(part) for part in parts) if name}
+
+
+def _process_aliases(value):
+    clean = normalise_process_name(value)
+    if not clean:
+        return set()
+    aliases = {clean}
+    stem, extension = os.path.splitext(clean)
+    if stem and extension in {".exe", ".app"}:
+        aliases.add(stem)
+    return aliases
+
+
+def game_mode_matches_processes(configured, running_names):
+    running = set()
+    for name in running_names or ():
+        running.update(_process_aliases(name))
+    for name in configured or ():
+        if _process_aliases(name).intersection(running):
+            return True
+    return False
+
+
+def remembered_track_mapping_key(title, artist=""):
+    title_key = normalised_text(title)
+    artist_key = normalised_text(artist)
+    return f"{title_key}|{artist_key}" if artist_key else title_key
+
+
+def _track_mappings(config_or_mappings):
+    if not isinstance(config_or_mappings, Mapping):
+        return {}
+    if "track_mappings" in config_or_mappings:
+        mappings = config_or_mappings.get("track_mappings")
+        return mappings if isinstance(mappings, Mapping) else {}
+    return config_or_mappings
+
+
+def remembered_track_mapping(config_or_mappings, title, artist=""):
+    """Find a correction saved under either track+artist or legacy title key."""
+
+    mappings = _track_mappings(config_or_mappings)
+    normalised_mappings = {
+        normalised_text(key): value
+        for key, value in mappings.items()
+        if isinstance(value, Mapping)
+    }
+    keys = (
+        remembered_track_mapping_key(title, artist),
+        remembered_track_mapping_key(title),
+    )
+    for key in keys:
+        value = normalised_mappings.get(normalised_text(key))
+        if isinstance(value, Mapping):
+            return value
+    return None
+
+
+def apply_track_mapping(config_or_mappings, track):
+    if not isinstance(track, Mapping):
+        return track
+    mapping = remembered_track_mapping(
+        config_or_mappings,
+        track.get("title", ""),
+        track.get("artist", ""),
+    )
+    if not mapping:
+        return dict(track)
+    merged = dict(track)
+    for field in ("title", "artist", "album", "art_url", "track_link", "duration"):
+        if mapping.get(field) not in (None, ""):
+            merged[field] = mapping[field]
+    return merged
+
+
+def _split_aliases(value):
+    items = value if isinstance(value, (list, tuple, set)) else str(value or "").replace("\n", ",").split(",")
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _normalise_art_value(value):
+    art = str(value or "").strip()
+    if not art:
+        return ""
+    if art.casefold().startswith(("http://", "https://", "mp:", "file://")):
+        return art
+    if os.path.exists(art):
+        return os.path.abspath(art)
+    return art
+
+
+def find_custom_album_art(config, *album_names):
+    """Return the first custom-art entry matching an album or alias."""
+
+    config = config if isinstance(config, Mapping) else {}
+    entries = config.get("custom_albums", [])
+    if not isinstance(entries, list):
+        return None
+    candidates = {normalised_text(name) for name in album_names if normalised_text(name)}
+    if not candidates:
+        return None
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        album = str(entry.get("album", "")).strip()
+        art_url = _normalise_art_value(entry.get("art_url", ""))
+        names = [album, *_split_aliases(entry.get("aliases", []))]
+        aliases = {normalised_text(name) for name in names if normalised_text(name)}
+        if art_url and candidates.intersection(aliases):
+            return {"album": album or next(iter(candidates)), "art_url": art_url}
+    return None
+
+
+def scrobble_eligible(elapsed, duration=0):
+    """Apply the Last.fm-compatible 30s + half-track/4-minute rule."""
+
+    elapsed = nonnegative_number(elapsed)
+    duration = nonnegative_number(duration)
+    if elapsed < SCROBBLE_MINIMUM_SECONDS:
+        return False
+    return bool(
+        (duration > 0 and elapsed >= duration * SCROBBLE_HALF_DURATION)
+        or elapsed >= SCROBBLE_FALLBACK_SECONDS
+    )

--- a/Shared/tests/test_playback.py
+++ b/Shared/tests/test_playback.py
@@ -1,0 +1,94 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+from Shared import playback
+
+
+def test_track_normalisation_is_bounded_and_clamps_position():
+    result = playback.normalise_track(
+        {
+            "status": "found",
+            "playback_status": "PAUSED",
+            "title": "  Song  ",
+            "artist": " Artist ",
+            "position": "500",
+            "duration": "180",
+            "_amazon_art_url": "https://example.com/art.jpg",
+        },
+        "native_backend",
+    )
+    assert result == {
+        "title": "Song",
+        "artist": "Artist",
+        "album": "",
+        "status": "paused",
+        "position": 180.0,
+        "duration": 180.0,
+        "art_url": "https://example.com/art.jpg",
+        "track_link": "",
+        "source": "native_backend",
+    }
+    assert playback.normalise_track({"artist": "Artist"}) is None
+
+
+def test_privacy_matching_accepts_string_and_list_keywords():
+    assert playback.privacy_match(
+        {"privacy_blocked_keywords": "Work, Secret\nPodcast"},
+        "My SECRET Song",
+    ) == "Matched privacy keyword: secret"
+    assert playback.privacy_keywords([" One ", "TWO"]) == ["one", "two"]
+    assert playback.privacy_match({"privacy_private_session": True}, "Song") == "Private session enabled"
+
+
+def test_process_matching_accepts_windows_and_macos_names_on_any_host():
+    configured = playback.configured_game_mode_processes(
+        {"game_mode_processes": "Game.exe, C:\\Tools\\OtherGame.exe\nMacGame.app"}
+    )
+    assert configured == {"game.exe", "othergame.exe", "macgame.app"}
+    assert playback.game_mode_matches_processes(configured, {"game"})
+    assert playback.game_mode_matches_processes({"othergame"}, {"OtherGame.exe"})
+    assert playback.game_mode_matches_processes({"macgame.app"}, {"MacGame"})
+    assert not playback.game_mode_matches_processes({"game"}, {"editor"})
+
+
+def test_remembered_mapping_supports_composite_and_legacy_title_keys():
+    track = {"title": " Raw   Song ", "artist": "Artist", "album": "Original"}
+    composite = {
+        "track_mappings": {
+            "raw song|artist": {"title": "Fixed", "album": "Correct Album"},
+        }
+    }
+    assert playback.apply_track_mapping(composite, track) == {
+        "title": "Fixed",
+        "artist": "Artist",
+        "album": "Correct Album",
+    }
+    legacy = {"track_mappings": {"raw song": {"artist": "Found Artist"}}}
+    assert playback.apply_track_mapping(legacy, track)["artist"] == "Found Artist"
+
+
+def test_custom_art_matches_aliases():
+    result = playback.find_custom_album_art(
+        {
+            "custom_albums": [
+                {
+                    "album": "Canonical Album",
+                    "aliases": "Deluxe Name, Localised Name",
+                    "art_url": "https://example.com/custom.png",
+                }
+            ]
+        },
+        " localised   name ",
+    )
+    assert result == {
+        "album": "Canonical Album",
+        "art_url": "https://example.com/custom.png",
+    }
+
+
+def test_scrobble_eligibility_boundaries():
+    assert not playback.scrobble_eligible(29.999, 40)
+    assert playback.scrobble_eligible(30, 60)
+    assert not playback.scrobble_eligible(30, 180)
+    assert playback.scrobble_eligible(90, 180)
+    assert not playback.scrobble_eligible(239.999, 0)
+    assert playback.scrobble_eligible(240, 0)

--- a/Shared/track_picker_ui.py
+++ b/Shared/track_picker_ui.py
@@ -1,0 +1,626 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+"""Shared PySide6 track-choice and correction dialogs.
+
+The public helpers intentionally return plain dictionaries so callers can use
+the dialogs in-process or through the Windows JSON-file subprocess protocol.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import QSize, Qt, QTimer, QUrl
+from PySide6.QtGui import QIcon, QPixmap
+from PySide6.QtNetwork import QNetworkAccessManager, QNetworkRequest
+from PySide6.QtWidgets import (
+    QApplication,
+    QButtonGroup,
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPlainTextEdit,
+    QPushButton,
+    QRadioButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+BG = "#18191c"
+CARD = "#232428"
+CARD_HOVER = "#2b2d31"
+INPUT = "#1e1f22"
+BORDER = "#3f4147"
+TEXT = "#f2f3f5"
+MUTED = "#a8aeb8"
+ACCENT = "#5865f2"
+ACCENT_HOVER = "#4752c4"
+DANGER = "#da373c"
+MAX_ARTWORK_BYTES = 5 * 1024 * 1024
+
+STYLE = f"""
+QDialog, QWidget#pickerRoot {{ background: {BG}; color: {TEXT}; }}
+QLabel {{ color: {TEXT}; }}
+QLabel[muted="true"] {{ color: {MUTED}; }}
+QFrame#trackCard {{ background: {CARD}; border: 1px solid {BORDER}; border-radius: 9px; }}
+QFrame#trackCard:hover {{ background: {CARD_HOVER}; }}
+QLineEdit, QDoubleSpinBox, QPlainTextEdit {{
+    background: {INPUT}; color: {TEXT}; border: 1px solid {BORDER};
+    border-radius: 6px; padding: 7px;
+}}
+QLineEdit:focus, QDoubleSpinBox:focus, QPlainTextEdit:focus {{ border-color: {ACCENT}; }}
+QPushButton {{
+    background: #34363c; color: {TEXT}; border: 1px solid #484b52;
+    border-radius: 6px; padding: 7px 14px; font-weight: 600;
+}}
+QPushButton:hover {{ background: #404249; }}
+QPushButton:disabled {{ color: #6d6f78; background: #25262a; }}
+QPushButton[primary="true"] {{ background: {ACCENT}; border-color: {ACCENT}; color: white; }}
+QPushButton[primary="true"]:hover {{ background: {ACCENT_HOVER}; }}
+QCheckBox, QRadioButton {{ color: {TEXT}; spacing: 8px; }}
+QScrollArea {{ border: 0; background: transparent; }}
+"""
+
+
+def track_payload(track):
+    """Return the stable subset accepted by the correction pipeline."""
+    track = track if isinstance(track, dict) else {}
+    try:
+        duration = max(0.0, float(track.get("duration") or 0))
+    except (TypeError, ValueError):
+        duration = 0.0
+    return {
+        "title": str(track.get("title") or "").strip(),
+        "artist": str(track.get("artist") or "").strip(),
+        "album": str(track.get("album") or "").strip(),
+        "art_url": str(track.get("art_url") or "").strip(),
+        "track_link": str(track.get("track_link") or "").strip(),
+        "duration": duration,
+    }
+
+
+def search_page(query, page_size, page, search_fn=None):
+    """Fetch a deterministic page while supporting legacy search callables."""
+    page_size = max(1, int(page_size or 5))
+    offset = max(0, int(page or 0)) * page_size
+    if search_fn:
+        try:
+            value = search_fn(query, limit=page_size, offset=offset)
+        except TypeError:
+            value = [] if offset else search_fn(query, limit=page_size)
+        return list(value or [])
+    try:
+        from Windows.album_art import search_tracks
+    except ImportError:
+        from album_art import search_tracks
+    return list(search_tracks(query, limit=page_size, offset=offset) or [])
+
+
+def _application():
+    app = QApplication.instance()
+    owns = app is None
+    if app is None:
+        app = QApplication([])
+        app.setApplicationName("Amazon Music RPC")
+        app.setOrganizationName("eripum9")
+    return app, owns
+
+
+def _set_icon(widget, icon_path):
+    if icon_path and Path(icon_path).is_file():
+        widget.setWindowIcon(QIcon(str(icon_path)))
+
+
+class TrackChoiceDialog(QDialog):
+    def __init__(
+        self,
+        title,
+        choices,
+        *,
+        search_query=None,
+        page_size=5,
+        prompt="No artist found. Select the correct track:",
+        remember=True,
+        search_fn=None,
+        icon_path=None,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.setObjectName("pickerRoot")
+        self.setStyleSheet(STYLE)
+        self.setWindowTitle("Amazon Music RPC — Choose track")
+        self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
+        self.setMinimumWidth(570)
+        self.setMaximumWidth(720)
+        _set_icon(self, icon_path)
+
+        self.search_query = str(search_query or "").strip()
+        self.page_size = max(1, int(page_size or 5))
+        self.search_fn = search_fn
+        self.pages = {0: list(choices or [])}
+        self.exhausted_pages = set()
+        self.current_page = 0
+        self.result_payload = {"index": -1, "remember": False, "track": None}
+        self._network = QNetworkAccessManager(self)
+        self._replies = set()
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(22, 20, 22, 18)
+        root.setSpacing(10)
+        heading = QLabel(f'“{str(title or "").strip()}”')
+        heading.setStyleSheet("font-size: 16px; font-weight: 700;")
+        heading.setWordWrap(True)
+        root.addWidget(heading)
+        hint = QLabel(prompt)
+        hint.setProperty("muted", True)
+        hint.setWordWrap(True)
+        root.addWidget(hint)
+
+        self.scroll = QScrollArea()
+        self.scroll.setWidgetResizable(True)
+        self.scroll.setMinimumHeight(250)
+        self.rows = QWidget()
+        self.rows.setObjectName("pickerRoot")
+        self.rows_layout = QVBoxLayout(self.rows)
+        self.rows_layout.setContentsMargins(0, 2, 0, 2)
+        self.rows_layout.setSpacing(7)
+        self.scroll.setWidget(self.rows)
+        root.addWidget(self.scroll, 1)
+
+        self.status = QLabel("")
+        self.status.setProperty("muted", True)
+        root.addWidget(self.status)
+
+        self.remember = QCheckBox("Always use this result for this title")
+        self.remember.setVisible(bool(remember))
+        root.addWidget(self.remember)
+
+        nav = QHBoxLayout()
+        self.previous = QPushButton("Previous")
+        self.previous.clicked.connect(lambda: self.load_page(self.current_page - 1))
+        nav.addWidget(self.previous)
+        self.page_label = QLabel("Page 1")
+        self.page_label.setProperty("muted", True)
+        nav.addWidget(self.page_label)
+        self.next = QPushButton("Next")
+        self.next.clicked.connect(lambda: self.load_page(self.current_page + 1))
+        nav.addWidget(self.next)
+        nav.addStretch(1)
+        skip = QPushButton("Skip")
+        skip.clicked.connect(self.reject)
+        nav.addWidget(skip)
+        self.select = QPushButton("Select")
+        self.select.setProperty("primary", True)
+        self.select.clicked.connect(self._select)
+        nav.addWidget(self.select)
+        root.addLayout(nav)
+
+        self.group = QButtonGroup(self)
+        self.group.setExclusive(True)
+        self.render_choices()
+
+    def _clear_rows(self):
+        for reply in list(self._replies):
+            reply.abort()
+            reply.deleteLater()
+        self._replies.clear()
+        while self.rows_layout.count():
+            item = self.rows_layout.takeAt(0)
+            widget = item.widget()
+            if widget:
+                widget.deleteLater()
+        self.group = QButtonGroup(self)
+        self.group.setExclusive(True)
+
+    def _request_art(self, label, url):
+        parsed = QUrl(str(url or ""))
+        if not parsed.isValid() or parsed.scheme() not in {"https", "http"}:
+            return
+        reply = self._network.get(QNetworkRequest(parsed))
+        self._replies.add(reply)
+        reply.downloadProgress.connect(
+            lambda received, total, item=reply: item.abort()
+            if received > MAX_ARTWORK_BYTES or total > MAX_ARTWORK_BYTES
+            else None
+        )
+
+        def done():
+            self._replies.discard(reply)
+            data = reply.readAll().data()
+            pixmap = QPixmap()
+            if data and pixmap.loadFromData(data):
+                try:
+                    label.setPixmap(
+                        pixmap.scaled(
+                            QSize(56, 56),
+                            Qt.AspectRatioMode.KeepAspectRatioByExpanding,
+                            Qt.TransformationMode.SmoothTransformation,
+                        )
+                    )
+                except RuntimeError:  # The user changed pages while artwork loaded.
+                    pass
+            reply.deleteLater()
+
+        reply.finished.connect(done)
+
+    def render_choices(self):
+        self._clear_rows()
+        choices = self.pages.get(self.current_page, [])
+        for index, choice in enumerate(choices):
+            payload = track_payload(choice)
+            card = QFrame()
+            card.setObjectName("trackCard")
+            layout = QHBoxLayout(card)
+            layout.setContentsMargins(11, 9, 12, 9)
+            radio = QRadioButton()
+            self.group.addButton(radio, index)
+            layout.addWidget(radio)
+            art = QLabel("♫")
+            art.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            art.setFixedSize(56, 56)
+            art.setStyleSheet("background: #35373c; border-radius: 6px; color: #777b84; font-size: 22px;")
+            layout.addWidget(art)
+            self._request_art(art, payload["art_url"])
+            text = QVBoxLayout()
+            title = QLabel(payload["title"] or "Untitled")
+            title.setStyleSheet("font-size: 14px; font-weight: 700;")
+            text.addWidget(title)
+            artist = QLabel(payload["artist"] or "Unknown artist")
+            text.addWidget(artist)
+            album = QLabel(payload["album"] or "Album unavailable")
+            album.setProperty("muted", True)
+            text.addWidget(album)
+            layout.addLayout(text, 1)
+            card.mousePressEvent = lambda _event, button=radio: button.setChecked(True)
+            self.rows_layout.addWidget(card)
+        if not choices:
+            empty = QLabel("No results found on this page.")
+            empty.setProperty("muted", True)
+            empty.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.rows_layout.addWidget(empty)
+        self.rows_layout.addStretch(1)
+        self.page_label.setText(f"Page {self.current_page + 1}")
+        self.previous.setEnabled(self.current_page > 0)
+        can_next = (
+            bool(self.search_query)
+            and self.current_page not in self.exhausted_pages
+            and len(choices) >= self.page_size
+        )
+        self.next.setEnabled(can_next)
+        self.select.setEnabled(bool(choices))
+
+    def load_page(self, page):
+        if page < 0:
+            return
+        if page in self.pages:
+            self.current_page = page
+            self.status.clear()
+            self.render_choices()
+            return
+        if not self.search_query:
+            return
+        self.status.setText("Searching…")
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            tracks = search_page(self.search_query, self.page_size, page, self.search_fn)
+        except Exception as error:
+            self.status.setText(f"Search failed: {error}")
+            return
+        finally:
+            QApplication.restoreOverrideCursor()
+        if not tracks:
+            self.exhausted_pages.add(max(0, page - 1))
+            self.status.setText("No more results.")
+            self.render_choices()
+            return
+        self.pages[page] = tracks
+        self.current_page = page
+        if len(tracks) < self.page_size:
+            self.exhausted_pages.add(page)
+        self.status.clear()
+        self.render_choices()
+
+    def _select(self):
+        index = self.group.checkedId()
+        choices = self.pages.get(self.current_page, [])
+        if not 0 <= index < len(choices):
+            QMessageBox.information(self, "Choose a track", "Select a track first.")
+            return
+        self.result_payload = {
+            "index": self.current_page * self.page_size + index,
+            "remember": bool(self.remember.isVisible() and self.remember.isChecked()),
+            "track": track_payload(choices[index]),
+        }
+        self.accept()
+
+
+class TrackInputDialog(QDialog):
+    def __init__(self, artist, *, search_fn=None, icon_path=None, parent=None):
+        super().__init__(parent)
+        self.setObjectName("pickerRoot")
+        self.setStyleSheet(STYLE)
+        self.setWindowTitle("Amazon Music RPC — Find track")
+        self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
+        self.setMinimumWidth(460)
+        _set_icon(self, icon_path)
+        self.artist = str(artist or "").strip()
+        self.search_fn = search_fn
+        self.result_payload = track_payload({})
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(22, 20, 22, 18)
+        title = QLabel(f'Artist: “{self.artist}”')
+        title.setStyleSheet("font-size: 16px; font-weight: 700;")
+        layout.addWidget(title)
+        hint = QLabel("Could not identify the song. Enter its title to search.")
+        hint.setProperty("muted", True)
+        layout.addWidget(hint)
+        self.entry = QLineEdit()
+        self.entry.setPlaceholderText("Song title")
+        self.entry.returnPressed.connect(self._search)
+        layout.addWidget(self.entry)
+        self.status = QLabel("")
+        self.status.setProperty("muted", True)
+        layout.addWidget(self.status)
+        buttons = QHBoxLayout()
+        buttons.addStretch(1)
+        skip = QPushButton("Skip")
+        skip.clicked.connect(self.reject)
+        buttons.addWidget(skip)
+        search = QPushButton("Search")
+        search.setProperty("primary", True)
+        search.clicked.connect(self._search)
+        buttons.addWidget(search)
+        layout.addLayout(buttons)
+        QTimer.singleShot(0, self.entry.setFocus)
+
+    def _search(self):
+        title = self.entry.text().strip()
+        if not title:
+            self.status.setText("Enter a song title first.")
+            return
+        query = f"{title} {self.artist}".strip()
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            tracks = search_page(query, 5, 0, self.search_fn)
+        except Exception as error:
+            self.status.setText(f"Search failed: {error}")
+            return
+        finally:
+            QApplication.restoreOverrideCursor()
+        if not tracks:
+            self.status.setText("No results found.")
+            return
+        picker = TrackChoiceDialog(
+            title,
+            tracks,
+            search_query=query,
+            page_size=5,
+            prompt="Select the correct track:",
+            remember=False,
+            search_fn=self.search_fn,
+            parent=self,
+        )
+        if picker.exec() == QDialog.DialogCode.Accepted and picker.result_payload["track"]:
+            self.result_payload = picker.result_payload["track"]
+            self.accept()
+
+
+class WrongSongDialog(QDialog):
+    def __init__(self, *, icon_path=None, parent=None):
+        super().__init__(parent)
+        self.setObjectName("pickerRoot")
+        self.setStyleSheet(STYLE)
+        self.setWindowTitle("Amazon Music RPC — Correct metadata")
+        self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
+        self.choice = ""
+        _set_icon(self, icon_path)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 22, 24, 20)
+        title = QLabel("Did we make a mistake?")
+        title.setStyleSheet("font-size: 16px; font-weight: 700;")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(title)
+        row = QHBoxLayout()
+        for label, choice in (("Wrong artist", "artist"), ("Wrong song", "title")):
+            button = QPushButton(label)
+            button.setProperty("primary", True)
+            button.clicked.connect(lambda _checked=False, value=choice: self._pick(value))
+            row.addWidget(button)
+        layout.addLayout(row)
+        cancel = QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        layout.addWidget(cancel)
+
+    def _pick(self, choice):
+        self.choice = choice
+        self.accept()
+
+
+class CorrectionDialog(QDialog):
+    """Edit metadata and optionally persist it as a raw-track mapping."""
+
+    def __init__(self, raw_track, corrected=None, *, icon_path=None, parent=None):
+        super().__init__(parent)
+        self.setObjectName("pickerRoot")
+        self.setStyleSheet(STYLE)
+        self.setWindowTitle("Amazon Music RPC — Correct this song")
+        self.setMinimumWidth(560)
+        self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
+        _set_icon(self, icon_path)
+        self.raw_track = track_payload(raw_track)
+        current = track_payload(corrected or raw_track)
+        self.result_payload = None
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 22, 24, 20)
+        title = QLabel("Correct the detected metadata")
+        title.setStyleSheet("font-size: 17px; font-weight: 700;")
+        layout.addWidget(title)
+        raw = QLabel(
+            f"Detected as {self.raw_track['title'] or 'unknown title'}"
+            f" — {self.raw_track['artist'] or 'unknown artist'}"
+        )
+        raw.setProperty("muted", True)
+        raw.setWordWrap(True)
+        layout.addWidget(raw)
+
+        form = QFormLayout()
+        form.setHorizontalSpacing(16)
+        self.fields = {}
+        for key, label in (
+            ("title", "Title"),
+            ("artist", "Artist"),
+            ("album", "Album"),
+            ("art_url", "Artwork URL"),
+            ("track_link", "Song URL"),
+        ):
+            edit = QLineEdit(current[key])
+            self.fields[key] = edit
+            form.addRow(label, edit)
+        self.duration = QDoubleSpinBox()
+        self.duration.setRange(0, 86400)
+        self.duration.setDecimals(1)
+        self.duration.setSuffix(" seconds")
+        self.duration.setValue(current["duration"])
+        form.addRow("Duration", self.duration)
+        layout.addLayout(form)
+        self.remember = QCheckBox("Remember this correction for the detected title and artist")
+        self.remember.setChecked(True)
+        layout.addWidget(self.remember)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Save
+        )
+        save = buttons.button(QDialogButtonBox.StandardButton.Save)
+        save.setText("Use correction")
+        save.setProperty("primary", True)
+        buttons.rejected.connect(self.reject)
+        buttons.accepted.connect(self._accept)
+        layout.addWidget(buttons)
+
+    def _accept(self):
+        corrected = {key: edit.text().strip() for key, edit in self.fields.items()}
+        corrected["duration"] = float(self.duration.value())
+        if not corrected["title"]:
+            QMessageBox.warning(self, "Missing title", "A corrected title is required.")
+            return
+        self.result_payload = {
+            "accepted": True,
+            "remember": self.remember.isChecked(),
+            "raw_title": self.raw_track["title"],
+            "raw_artist": self.raw_track["artist"],
+            "track": corrected,
+        }
+        self.accept()
+
+
+class LogConsoleWindow(QWidget):
+    def __init__(self, log_file_path, *, icon_path=None):
+        super().__init__()
+        self.setObjectName("pickerRoot")
+        self.setStyleSheet(STYLE)
+        self.setWindowTitle("Amazon Music RPC — Console")
+        self.resize(760, 460)
+        _set_icon(self, icon_path)
+        self.path = str(log_file_path)
+        self.position = 0
+        layout = QVBoxLayout(self)
+        self.text = QPlainTextEdit()
+        self.text.setReadOnly(True)
+        self.text.setStyleSheet("font-family: Menlo, Consolas, monospace;")
+        layout.addWidget(self.text)
+        self.timer = QTimer(self)
+        self.timer.setInterval(500)
+        self.timer.timeout.connect(self.poll)
+        self.timer.start()
+        self.poll()
+
+    def poll(self):
+        try:
+            with open(self.path, "r", encoding="utf-8", errors="replace") as handle:
+                handle.seek(self.position)
+                value = handle.read()
+                self.position = handle.tell()
+        except OSError:
+            return
+        if value:
+            self.text.moveCursor(self.text.textCursor().MoveOperation.End)
+            self.text.insertPlainText(value)
+            self.text.ensureCursorVisible()
+
+
+def show_choice_picker(
+    title,
+    choices,
+    search_query=None,
+    page_size=5,
+    prompt="No artist found. Select the correct track:",
+    remember=True,
+    search_fn=None,
+    icon_path=None,
+    parent=None,
+):
+    app, _owns = _application()
+    dialog = TrackChoiceDialog(
+        title,
+        choices,
+        search_query=search_query,
+        page_size=page_size,
+        prompt=prompt,
+        remember=remember,
+        search_fn=search_fn,
+        icon_path=icon_path,
+        parent=parent,
+    )
+    dialog.exec()
+    return dialog.result_payload
+
+
+def show_input_picker(artist, search_fn=None, icon_path=None, parent=None):
+    app, _owns = _application()
+    dialog = TrackInputDialog(
+        artist, search_fn=search_fn, icon_path=icon_path, parent=parent
+    )
+    dialog.exec()
+    return dialog.result_payload
+
+
+def show_wrong_song_dialog(icon_path=None, parent=None):
+    app, _owns = _application()
+    dialog = WrongSongDialog(icon_path=icon_path, parent=parent)
+    dialog.exec()
+    return {"choice": dialog.choice}
+
+
+def show_correction_dialog(raw_track, corrected=None, icon_path=None, parent=None):
+    app, _owns = _application()
+    dialog = CorrectionDialog(
+        raw_track, corrected, icon_path=icon_path, parent=parent
+    )
+    dialog.exec()
+    return dialog.result_payload or {
+        "accepted": False,
+        "remember": False,
+        "raw_title": str((raw_track or {}).get("title") or ""),
+        "raw_artist": str((raw_track or {}).get("artist") or ""),
+        "track": None,
+    }
+
+
+def show_console(log_file_path, icon_path=None):
+    app, owns = _application()
+    window = LogConsoleWindow(log_file_path, icon_path=icon_path)
+    window.show()
+    if owns:
+        app.exec()
+    return window

--- a/Windows/AmazonMusicRPC.spec
+++ b/Windows/AmazonMusicRPC.spec
@@ -1,11 +1,14 @@
 import os
+from PyInstaller.utils.hooks import collect_submodules
 
 block_cipher = None
 project_dir = os.path.dirname(os.path.abspath(SPEC))
+repository_dir = os.path.dirname(project_dir)
+shared_hidden_imports = collect_submodules('Shared')
 
 a = Analysis(
     [os.path.join(project_dir, 'main.py')],
-    pathex=[project_dir],
+    pathex=[repository_dir, project_dir],
     binaries=[],
     datas=[
         (os.path.join(project_dir, 'icon.png'), '.'),
@@ -13,6 +16,7 @@ a = Analysis(
     hiddenimports=[
         'PySide6.QtCore',
         'PySide6.QtGui',
+        'PySide6.QtNetwork',
         'PySide6.QtWidgets',
         'winsdk',
         'winsdk.windows.media.control',
@@ -51,6 +55,7 @@ a = Analysis(
         'amazify_rpc_bridge',
         'winsdk.windows.ui.notifications',
         'winsdk.windows.ui.notifications.management',
+        *shared_hidden_imports,
     ],
     hookspath=[],
     hooksconfig={},

--- a/Windows/desktop_runtime.py
+++ b/Windows/desktop_runtime.py
@@ -11,7 +11,7 @@ import tempfile
 
 from media_reader import get_track_sync
 from notification_reader import get_notification_track_sync, is_new_notification
-from album_art import get_album_art, search_tracks, find_custom_album_art
+from album_art import get_album_art, search_tracks
 from amazon_devtools import get_devtools_track_sync, apply_devtools_to_track, launch_amazon_music_devtools, restart_amazon_music_devtools, amazon_music_is_running, devtools_environment, amazon_music_search_link
 from amazon_status_overlay import AmazonStatusOverlay
 from discord_rpc import DiscordRPC
@@ -19,9 +19,9 @@ from config import load_config, update_config_fields, mutate_config_fields, DEFA
 from amazify_compat import amazify_compat_state, ensure_amazify_compat, push_rpc_state_to_amazify
 from amazify_rpc_bridge import start_amazify_rpc_bridge
 from metadata_pipeline import apply_art_result, apply_devtools_source, base_track_for_devtools, diagnostics_track_link, link_buttons, merge_notification_metadata, should_lookup_deezer_button
-from rpc_state import GameModeState, ResolvedTrackStore, TrackTimingState, configured_game_mode_processes, devtools_no_track_state, duration_value, game_mode_matches_processes, hidden_privacy_track, normalise_process_name, normalised_text, privacy_keywords, privacy_match, running_process_names, same_track_field, track_info_payload, track_position
+from rpc_state import GameModeState, ResolvedTrackStore, TrackTimingState, apply_track_mapping, configured_game_mode_processes, devtools_no_track_state, duration_value, find_custom_album_art, game_mode_matches_processes, hidden_privacy_track, normalise_process_name, normalise_track, normalised_text, privacy_keywords, privacy_match, remembered_track_mapping, running_process_names, same_track_field, scrobble_eligible, track_info_payload, track_position
 from status_summary import metadata_source_summary
-from tray_state import build_snapshot as build_tray_snapshot, format_seconds as _format_tray_seconds, icon_title as _tray_icon_title, signature as _tray_signature, trim as _tray_trim
+from tray_state import build_snapshot as build_tray_snapshot, icon_title as _tray_icon_title, signature as _tray_signature
 from updater import check_for_update, prompt_for_update, run_update_helper
 from app_models import DiagnosticsSnapshot
 from runtime_state import ApplicationState
@@ -264,9 +264,10 @@ def _read_tray_command():
 def _set_private_session_enabled(enabled):
     global current_config
     enabled = bool(enabled)
-    if enabled:
-        _set_scrobbling_privacy(True)
     config = load_config()
+    _set_scrobbling_privacy(
+        enabled and bool(config.get("privacy_disable_scrobbling", True))
+    )
     if bool(config.get("privacy_private_session")) == enabled:
         if not enabled:
             _set_scrobbling_privacy(False)
@@ -323,6 +324,15 @@ _track_info_payload = track_info_payload
 _normalise_process_name = normalise_process_name
 _configured_game_mode_processes = configured_game_mode_processes
 _game_mode_matches_processes = game_mode_matches_processes
+
+
+def _privacy_safe_devtools_state(state):
+    if not isinstance(state, dict):
+        return {}
+    allowed = ("enabled", "status", "detail", "source", "port", "method", "owner")
+    return {key: state[key] for key in allowed if key in state}
+
+
 _running_process_names = running_process_names
 
 
@@ -513,13 +523,13 @@ def _resolve_missing_artist(title, artist, config, raw_key):
     if raw_key in _skipped_keys:
         return title, artist
 
-    mappings = config.get("track_mappings", {})
-    mapping_key = title.lower().strip()
-    if mapping_key in mappings:
-        m = mappings[mapping_key]
-        result = (m.get("title", title), m.get("artist", ""))
+    mapping_key = _normalised_text(title)
+    remembered = remembered_track_mapping(config, title, artist)
+    if remembered:
+        mapped = apply_track_mapping(config, {"title": title, "artist": artist})
+        result = (mapped.get("title", title), mapped.get("artist", ""))
         _resolved_cache[raw_key] = result
-        _store_resolved_track(raw_key, m)
+        _store_resolved_track(raw_key, mapped)
         return result
 
     with _picker_lock:
@@ -586,7 +596,7 @@ def _try_scrobble(scrobbler, lb_scrobbler, title, artist, start_time, album, dur
     if not title or not start_time:
         return False
     elapsed = time.time() - start_time
-    if not (elapsed >= 30 and (duration > 0 and elapsed >= duration * 0.5 or elapsed >= 240)):
+    if not scrobble_eligible(elapsed, duration):
         return False
     if scrobbler:
         try:
@@ -656,7 +666,10 @@ def rpc_loop():
                 config["lastfm_api_key"],
                 config["lastfm_api_secret"],
                 config["lastfm_session_key"],
-                privacy_enabled=bool(config.get("privacy_private_session")),
+                privacy_enabled=bool(
+                    config.get("privacy_private_session")
+                    and privacy_disable_scrobbling
+                ),
             )
             lastfm_state = "active"
             print("[Last.fm] Scrobbler active.")
@@ -673,7 +686,10 @@ def rpc_loop():
             from listenbrainz_scrobbler import ListenBrainzScrobbler
             lb_scrobbler = ListenBrainzScrobbler(
                 config["listenbrainz_token"],
-                privacy_enabled=bool(config.get("privacy_private_session")),
+                privacy_enabled=bool(
+                    config.get("privacy_private_session")
+                    and privacy_disable_scrobbling
+                ),
             )
             listenbrainz_state = "active"
             print("[ListenBrainz] Scrobbler active.")
@@ -725,24 +741,29 @@ def rpc_loop():
             last_deezer_duration = deezer_duration
 
     def _update_state(track=None, presence=False, error="", privacy_reason=""):
+        hidden = bool(privacy_reason)
         _write_diagnostics_state(
             rpc_status="running" if rpc_running else "stopped",
             discord_status="connected" if rpc.connected else "retrying",
             client_id=client_id,
             track=track,
             presence_visible=presence,
-            album_art_url=last_art_url or "",
-            album_name=last_album_name or "",
-            track_link=_diagnostics_track_link(track),
+            album_art_url="" if hidden else (last_art_url or ""),
+            album_name="" if hidden else (last_album_name or ""),
+            track_link="" if hidden else _diagnostics_track_link(track),
             notification_enabled=notification_enrichment_enabled,
-            notification=_current_notif_data,
-            amazon_devtools=_current_amazon_devtools,
+            notification=None if hidden else _current_notif_data,
+            amazon_devtools=(
+                _privacy_safe_devtools_state(_current_amazon_devtools)
+                if hidden
+                else _current_amazon_devtools
+            ),
             amazify=_amazify_compat_snapshot(),
             scrobbling=scrobbling_state,
             privacy={
                 "private_session": bool(config.get("privacy_private_session")),
-                "blocked_keywords": config.get("privacy_blocked_keywords", ""),
-                "hidden": bool(privacy_reason),
+                "blocked_keywords": "" if hidden else config.get("privacy_blocked_keywords", ""),
+                "hidden": hidden,
                 "reason": privacy_reason,
             },
             last_error=error,
@@ -881,6 +902,14 @@ def rpc_loop():
                 _update_state(track=None, presence=False)
                 time.sleep(3)
                 continue
+
+            # Native sources keep their private enrichment fields, while the
+            # common playback fields follow the same normalization rules as
+            # the macOS runtime.
+            normalised_track = normalise_track(track)
+            if normalised_track:
+                for field in ("title", "artist", "album", "status", "position", "duration"):
+                    track[field] = normalised_track[field]
 
             if track["status"] == "paused":
                 last_playback_status = "paused"
@@ -1036,14 +1065,19 @@ def rpc_loop():
                 last_deezer_track_link = None
 
                 resolved = _resolved_art(raw_key, title, artist, track.get("album", ""))
-                fetched = None if resolved or track.get("_amazon_art_url") else get_album_art(title, artist)
+                fetched = (
+                    None
+                    if privacy_reason or resolved or track.get("_amazon_art_url")
+                    else get_album_art(title, artist)
+                )
                 art_state = apply_art_result(track, resolved, fetched, _notif_album, last_album_name)
                 last_art_url = art_state["art_url"]
                 last_album_name = art_state["album"]
                 last_deezer_track_link = art_state["deezer_link"]
                 last_deezer_duration = art_state["duration"]
                 last_amazon_track_link = art_state["amazon_link"]
-                _ensure_deezer_button_link(title, artist)
+                if not privacy_reason:
+                    _ensure_deezer_button_link(title, artist)
                 last_art_url, last_album_name = _apply_custom_album_override(
                     config, last_art_url, last_album_name, _notif_album, track.get("album", "")
                 )
@@ -1074,14 +1108,19 @@ def rpc_loop():
                                 pass
             elif raw_key in _resolved_cache and last_art_fetch_key != track_art_key:
                 resolved = _resolved_art(raw_key, title, artist, track.get("album", ""))
-                fetched = None if resolved or track.get("_amazon_art_url") else get_album_art(title, artist)
+                fetched = (
+                    None
+                    if privacy_reason or resolved or track.get("_amazon_art_url")
+                    else get_album_art(title, artist)
+                )
                 art_state = apply_art_result(track, resolved, fetched, _notif_album, last_album_name)
                 last_art_url = art_state["art_url"]
                 last_album_name = art_state["album"]
                 last_deezer_track_link = art_state["deezer_link"]
                 last_deezer_duration = art_state["duration"]
                 last_amazon_track_link = art_state["amazon_link"]
-                _ensure_deezer_button_link(title, artist)
+                if not privacy_reason:
+                    _ensure_deezer_button_link(title, artist)
                 last_art_url, last_album_name = _apply_custom_album_override(
                     config, last_art_url, last_album_name, _notif_album, track.get("album", "")
                 )
@@ -1118,7 +1157,7 @@ def rpc_loop():
             if _notif_album:
                 last_album_name = _notif_album
                 notif_art_key = f"{title}|{artist}|{_notif_album}".lower()
-                if _notif_art_fetched_for != notif_art_key:
+                if not privacy_reason and _notif_art_fetched_for != notif_art_key:
                     _notif_art, _notif_aname, _notif_link, _notif_dur = get_album_art(title, f"{artist} {_notif_album}")
                     if _notif_art:
                         last_art_url = _notif_art
@@ -1299,8 +1338,17 @@ def _on_config_changed(previous, current, previous_rpc, current_rpc):
     current_config = current
     application_state.replace_config(current)
     _sync_status_overlay(current)
-    if current.get("privacy_private_session") != previous.get("privacy_private_session"):
-        _set_scrobbling_privacy(bool(current.get("privacy_private_session")))
+    privacy_gate_changed = any(
+        current.get(key) != previous.get(key)
+        for key in ("privacy_private_session", "privacy_disable_scrobbling")
+    )
+    if privacy_gate_changed:
+        _set_scrobbling_privacy(
+            bool(
+                current.get("privacy_private_session")
+                and current.get("privacy_disable_scrobbling", True)
+            )
+        )
     if current_rpc != previous_rpc:
         if current.get("privacy_private_session") and not previous.get("privacy_private_session"):
             clear_current_presence("private session enabled")

--- a/Windows/lastfm.py
+++ b/Windows/lastfm.py
@@ -4,7 +4,10 @@ import pylast
 import traceback
 import threading
 
-from task_supervisor import TaskSupervisor
+try:
+    from .task_supervisor import TaskSupervisor
+except ImportError:  # Direct execution and the existing Windows frozen entrypoint.
+    from task_supervisor import TaskSupervisor
 
 
 class LastFMScrobbler:

--- a/Windows/listenbrainz_scrobbler.py
+++ b/Windows/listenbrainz_scrobbler.py
@@ -4,7 +4,10 @@ import traceback
 import threading
 import liblistenbrainz
 
-from task_supervisor import TaskSupervisor
+try:
+    from .task_supervisor import TaskSupervisor
+except ImportError:  # Direct execution and the existing Windows frozen entrypoint.
+    from task_supervisor import TaskSupervisor
 
 
 class ListenBrainzScrobbler:

--- a/Windows/rpc_state.py
+++ b/Windows/rpc_state.py
@@ -3,88 +3,38 @@
 import csv
 import os
 import subprocess
+import sys
 import time
 
 
+# ``python Windows/main.py`` puts only ``Windows`` on the import path.  Add the
+# repository root before importing the source-shared package; frozen builds
+# include the same package through their PyInstaller spec.
+_REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if not getattr(sys, "frozen", False) and _REPOSITORY_ROOT not in sys.path:
+    sys.path.insert(0, _REPOSITORY_ROOT)
+
+from Shared.playback import (  # noqa: E402, F401 -- compatibility re-exports
+    apply_track_mapping,
+    configured_game_mode_processes,
+    duration_value,
+    find_custom_album_art,
+    game_mode_matches_processes,
+    normalise_process_name,
+    normalise_track,
+    normalised_text,
+    privacy_keywords,
+    privacy_match,
+    privacy_reason,
+    remembered_track_mapping,
+    remembered_track_mapping_key,
+    same_track_field,
+    scrobble_eligible,
+    track_info_payload,
+)
+
+
 PLAYBACK_TIME_DRIFT_SECONDS = 1.0
-
-
-def privacy_keywords(config):
-    raw = config.get("privacy_blocked_keywords", "")
-    return [item.strip().lower() for item in raw.replace("\n", ",").split(",") if item.strip()]
-
-
-def privacy_match(config, title="", artist="", album=""):
-    if config.get("privacy_private_session"):
-        return "Private session enabled"
-    haystack = f"{title} {artist} {album}".lower()
-    for keyword in privacy_keywords(config):
-        if keyword in haystack:
-            return f"Matched privacy keyword: {keyword}"
-    return ""
-
-
-def normalised_text(value):
-    return " ".join(str(value or "").strip().lower().split())
-
-
-def same_track_field(left, right):
-    left = normalised_text(left)
-    right = normalised_text(right)
-    return bool(left and right and left == right)
-
-
-def duration_value(value):
-    try:
-        return max(0, int(float(value or 0)))
-    except (TypeError, ValueError):
-        return 0
-
-
-def track_info_payload(track):
-    return {
-        "title": track.get("title", ""),
-        "artist": track.get("artist", ""),
-        "album": track.get("album", ""),
-        "art_url": track.get("art_url", ""),
-        "track_link": track.get("track_link", ""),
-        "duration": duration_value(track.get("duration", 0)),
-    }
-
-
-def normalise_process_name(value):
-    text = str(value or "").strip().strip('"').strip("'").lower()
-    return os.path.basename(text)
-
-
-def configured_game_mode_processes(config):
-    value = config.get("game_mode_processes", "")
-    if isinstance(value, list):
-        parts = value
-    else:
-        parts = str(value or "").replace(";", ",").replace("\n", ",").split(",")
-    return {name for name in (normalise_process_name(part) for part in parts) if name}
-
-
-def game_mode_matches_processes(configured, running_names):
-    running = set()
-    for name in running_names:
-        clean = normalise_process_name(name)
-        if clean:
-            running.add(clean)
-            stem, ext = os.path.splitext(clean)
-            if ext == ".exe" and stem:
-                running.add(stem)
-    for name in configured:
-        clean = normalise_process_name(name)
-        if clean in running:
-            return True
-        stem, ext = os.path.splitext(clean)
-        if ext == ".exe" and stem in running:
-            return True
-        if not ext and f"{clean}.exe" in running:
-            return True
-    return False
 
 
 def _tasklist_executable():

--- a/Windows/tests/test_main_logic.py
+++ b/Windows/tests/test_main_logic.py
@@ -75,3 +75,29 @@ def test_devtools_no_track_state_preserves_actionable_statuses():
     assert main._devtools_no_track_state(True, restarting) == restarting
     assert waiting["status"] == "waiting"
     assert main._devtools_no_track_state(False, unavailable) == unavailable
+
+
+def test_private_diagnostics_devtools_state_drops_track_metadata():
+    state = {
+        "enabled": True,
+        "status": "found",
+        "detail": "metadata found",
+        "source": "amazon_devtools",
+        "port": 52856,
+        "title": "Private Song",
+        "artist": "Private Artist",
+        "album": "Private Album",
+        "art_url": "https://example.test/private.jpg",
+        "track_link": "https://music.amazon.com/private",
+        "position": 42,
+        "duration": 180,
+    }
+
+    safe = main._privacy_safe_devtools_state(state)
+    assert safe == {
+        "enabled": True,
+        "status": "found",
+        "detail": "metadata found",
+        "source": "amazon_devtools",
+        "port": 52856,
+    }

--- a/Windows/tests/test_project_docs.py
+++ b/Windows/tests/test_project_docs.py
@@ -71,12 +71,14 @@ def test_trust_documents_cover_v5_boundaries():
     assert {"api.deezer.com", "itunes.apple.com", "api.github.com"}.issubset(destinations)
 
 
-def test_platform_roadmap_keeps_linux_and_macos_out_of_scope():
+def test_platform_roadmap_keeps_windows_stable_and_tracks_macos_beta():
     roadmap = (ROOT / "docs/platform-roadmap.md").read_text(encoding="utf-8")
-    assert "Windows is the sole supported target" in roadmap
+    assert "Windows is stable; macOS is an experimental beta" in roadmap
+    assert "| macOS | Beta prototype | `beta/MacOS` |" in roadmap
+    assert "Fundamental user-visible behavior must be implemented and tested for both platforms" in roadmap
     assert "Android support is discontinued" in roadmap
-    assert "Linux and macOS are out of scope" in roadmap
-    assert "official desktop apps" in roadmap
+    assert "Linux remains out of scope" in roadmap
+    assert "official desktop app surface" in roadmap
     assert "research/linux-metadata-rpc" not in roadmap
     assert "research/macos-metadata-rpc" not in roadmap
 

--- a/Windows/tests/test_project_docs.py
+++ b/Windows/tests/test_project_docs.py
@@ -71,10 +71,12 @@ def test_trust_documents_cover_v5_boundaries():
     assert {"api.deezer.com", "itunes.apple.com", "api.github.com"}.issubset(destinations)
 
 
-def test_platform_roadmap_keeps_windows_stable_and_tracks_macos_beta():
+def test_platform_roadmap_keeps_windows_stable_and_macos_active_beta():
     roadmap = (ROOT / "docs/platform-roadmap.md").read_text(encoding="utf-8")
-    assert "Windows is stable; macOS is an experimental beta" in roadmap
-    assert "| macOS | Beta prototype | `beta/MacOS` |" in roadmap
+    assert "Windows is the published stable platform" in roadmap
+    assert "macOS is an active beta development target" in roadmap
+    assert "| macOS | Active beta | `master` |" in roadmap
+    assert "not yet a published stable or notarized release" in roadmap
     assert "Fundamental user-visible behavior must be implemented and tested for both platforms" in roadmap
     assert "Android support is discontinued" in roadmap
     assert "Linux remains out of scope" in roadmap

--- a/Windows/track_picker.py
+++ b/Windows/track_picker.py
@@ -1,532 +1,92 @@
 # MIT License - Copyright (c) 2026 eripum9
 
-import sys
+"""Windows adapter for the shared PySide6 correction picker.
+
+The JSON-file CLI is retained because the Windows runtime launches picker
+dialogs in a helper process to keep its polling loop responsive.
+"""
+
+from __future__ import annotations
+
 import json
-import tkinter as tk
-from tkinter import font as tkfont
-from safe_image import load_thumbnail_image
+import sys
+from pathlib import Path
 
-BG = "#202020"
-CARD_BG = "#2d2d2d"
-FG = "#e4e4e4"
-FG_DIM = "#999"
-ACCENT = "#5865f2"
-BTN_BG = "#383838"
-BORDER = "#3d3d3d"
 
-_photo_refs = []
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
+from Shared.track_picker_ui import (  # noqa: E402
+    show_choice_picker as _show_choice_picker,
+    show_console as _show_console,
+    show_correction_dialog as _show_correction_dialog,
+    show_input_picker as _show_input_picker,
+    show_wrong_song_dialog as _show_wrong_song_dialog,
+)
 
-def _load_thumbnail(url, size=50):
-    try:
-        from PIL import ImageTk
-        img = load_thumbnail_image(url, size)
-        return ImageTk.PhotoImage(img)
-    except Exception:
-        return None
 
+DEFAULT_ICON = str(Path(__file__).with_name("icon.png"))
 
-def _track_payload(track):
-    return {
-        "title": track.get("title", ""),
-        "artist": track.get("artist", ""),
-        "album": track.get("album", ""),
-        "art_url": track.get("art_url", ""),
-        "track_link": track.get("track_link", ""),
-        "duration": track.get("duration", 0) or 0,
-    }
 
+def show_choice_picker(*args, **kwargs):
+    kwargs.setdefault("icon_path", DEFAULT_ICON)
+    return _show_choice_picker(*args, **kwargs)
 
-def _search_page(query, page_size, page, search_fn=None):
-    offset = max(0, int(page)) * max(1, int(page_size))
-    if search_fn:
-        try:
-            return search_fn(query, limit=page_size, offset=offset)
-        except TypeError:
-            if offset:
-                return []
-            return search_fn(query, limit=page_size)
-    from album_art import search_tracks
-    return search_tracks(query, limit=page_size, offset=offset)
 
+def show_input_picker(*args, **kwargs):
+    kwargs.setdefault("icon_path", DEFAULT_ICON)
+    return _show_input_picker(*args, **kwargs)
 
-def _center_window(root, min_width):
-    root.update_idletasks()
-    w = max(root.winfo_reqwidth(), min_width)
-    h = root.winfo_reqheight()
-    x = (root.winfo_screenwidth() - w) // 2
-    y = (root.winfo_screenheight() - h) // 2
-    root.geometry(f"{w}x{h}+{x}+{y}")
 
+def show_wrong_song_dialog(*args, **kwargs):
+    kwargs.setdefault("icon_path", DEFAULT_ICON)
+    return _show_wrong_song_dialog(*args, **kwargs)
 
-def show_choice_picker(title, choices, search_query=None, page_size=5, prompt="No artist found. Select the correct track:", remember=True, search_fn=None):
-    result = {"index": -1, "remember": False, "track": None}
-    _photo_refs.clear()
-    page_size = max(1, int(page_size or 5))
 
-    root = tk.Tk()
-    root.title("Amazon Music RPC")
-    root.configure(bg=BG)
-    root.resizable(False, False)
-    root.attributes("-topmost", True)
+def show_correction_dialog(*args, **kwargs):
+    kwargs.setdefault("icon_path", DEFAULT_ICON)
+    return _show_correction_dialog(*args, **kwargs)
 
-    main_font = tkfont.Font(family="Segoe UI", size=10)
-    title_font = tkfont.Font(family="Segoe UI", size=11, weight="bold")
-    small_font = tkfont.Font(family="Segoe UI", size=9)
 
-    tk.Label(
-        root, text=f'"{title}"', bg=BG, fg=FG, font=title_font,
-        wraplength=440, justify="left"
-    ).pack(padx=20, pady=(16, 4), anchor="w")
-
-    tk.Label(
-        root, text=prompt,
-        bg=BG, fg=FG_DIM, font=small_font
-    ).pack(padx=20, pady=(0, 10), anchor="w")
-
-    selected = tk.IntVar(value=-1)
-    pages = {0: list(choices or [])}
-    current_page = [0]
-    exhausted_pages = set()
-    list_frame = tk.Frame(root, bg=BG)
-    list_frame.pack(fill="x")
-    status_label = tk.Label(root, text="", bg=BG, fg=FG_DIM, font=small_font)
-    status_label.pack(padx=20, pady=(4, 2), anchor="w")
-
-    def render_choices():
-        for child in list_frame.winfo_children():
-            child.destroy()
-        _photo_refs.clear()
-        selected.set(-1)
-        page_choices = pages.get(current_page[0], [])
-        if not page_choices:
-            tk.Label(
-                list_frame, text="No results found on this page.",
-                bg=BG, fg=FG_DIM, font=small_font
-            ).pack(padx=20, pady=12, anchor="w")
-        for i, c in enumerate(page_choices):
-            row_frame = tk.Frame(list_frame, bg=CARD_BG, highlightbackground=BORDER, highlightthickness=1)
-            row_frame.pack(fill="x", padx=16, pady=2)
-
-            rb = tk.Radiobutton(
-                row_frame, variable=selected, value=i,
-                bg=CARD_BG, selectcolor=BTN_BG,
-                activebackground=CARD_BG, highlightthickness=0, bd=0
-            )
-            rb.pack(side="left", padx=(8, 4), pady=6)
-
-            thumb = _load_thumbnail(c.get("art_url", ""), 48) if c.get("art_url") else None
-            if thumb:
-                _photo_refs.append(thumb)
-                tk.Label(row_frame, image=thumb, bg=CARD_BG, bd=0).pack(side="left", padx=(0, 8), pady=4)
-            else:
-                placeholder = tk.Frame(row_frame, bg="#444", width=48, height=48)
-                placeholder.pack_propagate(False)
-                placeholder.pack(side="left", padx=(0, 8), pady=4)
-
-            info_frame = tk.Frame(row_frame, bg=CARD_BG)
-            info_frame.pack(side="left", fill="x", expand=True, pady=4)
-
-            tk.Label(
-                info_frame, text=c.get("title", ""), bg=CARD_BG, fg="#fff",
-                font=main_font, anchor="w"
-            ).pack(anchor="w")
-            tk.Label(
-                info_frame, text=c.get("artist", ""), bg=CARD_BG, fg=FG,
-                font=small_font, anchor="w"
-            ).pack(anchor="w")
-            album_text = c.get("album", "")
-            if album_text:
-                tk.Label(
-                    info_frame, text=album_text, bg=CARD_BG, fg=FG_DIM,
-                    font=small_font, anchor="w"
-                ).pack(anchor="w")
-        page_label.configure(text=f"Page {current_page[0] + 1}")
-        prev_btn.configure(state="normal" if current_page[0] > 0 else "disabled")
-        can_next = bool(search_query) and current_page[0] not in exhausted_pages and len(page_choices) >= page_size
-        next_btn.configure(state="normal" if can_next else "disabled")
-        _center_window(root, 500)
-
-    def load_page(page):
-        if page < 0:
-            return
-        if page in pages:
-            current_page[0] = page
-            status_label.configure(text="")
-            render_choices()
-            return
-        if not search_query:
-            return
-        status_label.configure(text="Searching...")
-        root.update_idletasks()
-        tracks = _search_page(search_query, page_size, page, search_fn)
-        if not tracks:
-            exhausted_pages.add(page - 1)
-            status_label.configure(text="No more results.")
-            render_choices()
-            return
-        pages[page] = tracks
-        current_page[0] = page
-        status_label.configure(text="")
-        if len(tracks) < page_size:
-            exhausted_pages.add(page)
-        render_choices()
-
-    remember_var = tk.BooleanVar(value=False)
-    if remember:
-        tk.Checkbutton(
-            root, text="Always use this for this title", variable=remember_var,
-            bg=BG, fg=FG_DIM, selectcolor=BTN_BG,
-            activebackground=BG, activeforeground=FG,
-            font=small_font, highlightthickness=0, bd=0
-        ).pack(padx=20, pady=(6, 8), anchor="w")
-
-    btn_frame = tk.Frame(root, bg=BG)
-    btn_frame.pack(fill="x", padx=16, pady=(0, 14))
-
-    def on_select():
-        selected_index = selected.get()
-        page_choices = pages.get(current_page[0], [])
-        if selected_index >= 0 and selected_index < len(page_choices):
-            chosen = page_choices[selected_index]
-            result["index"] = current_page[0] * page_size + selected_index
-            result["remember"] = remember_var.get()
-            result["track"] = _track_payload(chosen)
-        root.destroy()
-
-    def on_skip():
-        root.destroy()
-
-    prev_btn = tk.Button(
-        btn_frame, text="Previous", command=lambda: load_page(current_page[0] - 1),
-        bg=BTN_BG, fg=FG, font=main_font, relief="flat",
-        padx=12, pady=4, cursor="hand2"
-    )
-    prev_btn.pack(side="left")
-
-    page_label = tk.Label(btn_frame, text="Page 1", bg=BG, fg=FG_DIM, font=small_font)
-    page_label.pack(side="left", padx=8)
-
-    next_btn = tk.Button(
-        btn_frame, text="Next", command=lambda: load_page(current_page[0] + 1),
-        bg=BTN_BG, fg=FG, font=main_font, relief="flat",
-        padx=12, pady=4, cursor="hand2"
-    )
-    next_btn.pack(side="left")
-
-    tk.Button(
-        btn_frame, text="Select", command=on_select,
-        bg=ACCENT, fg="#fff", font=main_font, relief="flat",
-        padx=16, pady=4, cursor="hand2"
-    ).pack(side="right", padx=(5, 0))
-
-    tk.Button(
-        btn_frame, text="Skip", command=on_skip,
-        bg=BTN_BG, fg=FG, font=main_font, relief="flat",
-        padx=16, pady=4, cursor="hand2"
-    ).pack(side="right")
-
-    render_choices()
-
-    root.protocol("WM_DELETE_WINDOW", on_skip)
-    root.mainloop()
-
-    return result
-
-
-def _show_confirm(root, track_info, main_font, small_font):
-    _photo_refs.clear()
-    confirm_result = {"accepted": False}
-
-    win = tk.Toplevel(root)
-    win.title("Amazon Music RPC")
-    win.configure(bg=BG)
-    win.resizable(False, False)
-    win.attributes("-topmost", True)
-    win.grab_set()
-
-    tk.Label(
-        win, text="Is this the right track?",
-        bg=BG, fg=FG, font=tkfont.Font(family="Segoe UI", size=11, weight="bold")
-    ).pack(padx=20, pady=(16, 10), anchor="w")
-
-    card = tk.Frame(win, bg=CARD_BG, highlightbackground=BORDER, highlightthickness=1)
-    card.pack(fill="x", padx=16, pady=(0, 10))
-
-    thumb = _load_thumbnail(track_info.get("art_url", ""), 64) if track_info.get("art_url") else None
-    if thumb:
-        _photo_refs.append(thumb)
-        tk.Label(card, image=thumb, bg=CARD_BG, bd=0).pack(side="left", padx=(12, 10), pady=10)
-    else:
-        placeholder = tk.Frame(card, bg="#444", width=64, height=64)
-        placeholder.pack_propagate(False)
-        placeholder.pack(side="left", padx=(12, 10), pady=10)
-
-    info = tk.Frame(card, bg=CARD_BG)
-    info.pack(side="left", fill="x", expand=True, pady=10, padx=(0, 12))
-
-    tk.Label(info, text=track_info.get("title", ""), bg=CARD_BG, fg="#fff", font=main_font, anchor="w").pack(anchor="w")
-    tk.Label(info, text=track_info.get("artist", ""), bg=CARD_BG, fg=FG, font=main_font, anchor="w").pack(anchor="w")
-    album = track_info.get("album", "")
-    if album:
-        tk.Label(info, text=album, bg=CARD_BG, fg=FG_DIM, font=small_font, anchor="w").pack(anchor="w")
-
-    btn_frame = tk.Frame(win, bg=BG)
-    btn_frame.pack(fill="x", padx=16, pady=(0, 14))
-
-    def on_yes():
-        confirm_result["accepted"] = True
-        win.destroy()
-
-    def on_no():
-        win.destroy()
-
-    tk.Button(
-        btn_frame, text="Yes", command=on_yes,
-        bg=ACCENT, fg="#fff", font=main_font, relief="flat",
-        padx=16, pady=4, cursor="hand2"
-    ).pack(side="right", padx=(5, 0))
-
-    tk.Button(
-        btn_frame, text="Try Again", command=on_no,
-        bg=BTN_BG, fg=FG, font=main_font, relief="flat",
-        padx=16, pady=4, cursor="hand2"
-    ).pack(side="right")
-
-    win.update_idletasks()
-    w = max(win.winfo_reqwidth(), 400)
-    h = win.winfo_reqheight()
-    x = (win.winfo_screenwidth() - w) // 2
-    y = (win.winfo_screenheight() - h) // 2
-    win.geometry(f"{w}x{h}+{x}+{y}")
-
-    win.protocol("WM_DELETE_WINDOW", on_no)
-    win.wait_window()
-    return confirm_result["accepted"]
-
-
-def show_input_picker(artist, search_fn=None):
-    result = {"title": "", "artist": "", "album": "", "art_url": ""}
-
-    root = tk.Tk()
-    root.title("Amazon Music RPC")
-    root.configure(bg=BG)
-    root.resizable(False, False)
-    root.attributes("-topmost", True)
-
-    main_font = tkfont.Font(family="Segoe UI", size=10)
-    title_font = tkfont.Font(family="Segoe UI", size=11, weight="bold")
-    small_font = tkfont.Font(family="Segoe UI", size=9)
-
-    tk.Label(
-        root, text=f'Artist: "{artist}"', bg=BG, fg=FG, font=title_font
-    ).pack(padx=20, pady=(16, 4), anchor="w")
-
-    tk.Label(
-        root, text="Could not identify the song. Enter the title:",
-        bg=BG, fg=FG_DIM, font=small_font
-    ).pack(padx=20, pady=(0, 10), anchor="w")
-
-    entry = tk.Entry(
-        root, bg=BTN_BG, fg=FG, insertbackground=FG,
-        font=main_font, relief="flat", bd=5
-    )
-    entry.pack(fill="x", padx=20, pady=(0, 10))
-    entry.focus_set()
-
-    btn_frame = tk.Frame(root, bg=BG)
-    btn_frame.pack(fill="x", padx=16, pady=(0, 14))
-    status_label = tk.Label(root, text="", bg=BG, fg=FG_DIM, font=small_font)
-    status_label.pack(padx=20, pady=(0, 8), anchor="w")
-
-    def on_search(event=None):
-        query = entry.get().strip()
-        if not query:
-            return
-        search_query = f"{query} {artist}"
-        status_label.configure(text="Searching...")
-        root.update_idletasks()
-        tracks = _search_page(search_query, 5, 0, search_fn)
-        if not tracks:
-            status_label.configure(text="No results found.")
-            return
-        root.destroy()
-        picked = show_choice_picker(
-            query,
-            tracks,
-            search_query=search_query,
-            page_size=5,
-            prompt="Select the correct track:",
-            remember=False,
-            search_fn=search_fn,
-        )
-        track_info = picked.get("track") or {}
-        if track_info:
-            result["title"] = track_info.get("title", query)
-            result["artist"] = track_info.get("artist", artist)
-            result["album"] = track_info.get("album", "")
-            result["art_url"] = track_info.get("art_url", "")
-            result["track_link"] = track_info.get("track_link", "")
-            result["duration"] = track_info.get("duration", 0) or 0
-
-    def on_skip():
-        root.destroy()
-
-    entry.bind("<Return>", on_search)
-
-    tk.Button(
-        btn_frame, text="Search", command=on_search,
-        bg=ACCENT, fg="#fff", font=main_font, relief="flat",
-        padx=16, pady=4, cursor="hand2"
-    ).pack(side="right", padx=(5, 0))
-
-    tk.Button(
-        btn_frame, text="Skip", command=on_skip,
-        bg=BTN_BG, fg=FG, font=main_font, relief="flat",
-        padx=16, pady=4, cursor="hand2"
-    ).pack(side="right")
-
-    _center_window(root, 400)
-
-    root.protocol("WM_DELETE_WINDOW", on_skip)
-    root.mainloop()
-
-    return result
-
-
-def show_wrong_song_dialog():
-    result = {"choice": ""}
-
-    root = tk.Tk()
-    root.title("Amazon Music RPC")
-    root.configure(bg=BG)
-    root.resizable(False, False)
-    root.attributes("-topmost", True)
-
-    title_font = tkfont.Font(family="Segoe UI", size=11, weight="bold")
-    main_font = tkfont.Font(family="Segoe UI", size=10)
-
-    tk.Label(
-        root, text="Did we make a mistake?",
-        bg=BG, fg=FG, font=title_font
-    ).pack(padx=24, pady=(20, 16))
-
-    btn_frame = tk.Frame(root, bg=BG)
-    btn_frame.pack(fill="x", padx=24, pady=(0, 8))
-
-    def pick_artist():
-        result["choice"] = "artist"
-        root.destroy()
-
-    def pick_title():
-        result["choice"] = "title"
-        root.destroy()
-
-    tk.Button(
-        btn_frame, text="Wrong Artist", command=pick_artist,
-        bg=ACCENT, fg="#fff", font=main_font, relief="flat",
-        padx=18, pady=8, cursor="hand2", width=14
-    ).pack(side="left", padx=(0, 6), expand=True)
-
-    tk.Button(
-        btn_frame, text="Wrong Song", command=pick_title,
-        bg=ACCENT, fg="#fff", font=main_font, relief="flat",
-        padx=18, pady=8, cursor="hand2", width=14
-    ).pack(side="right", padx=(6, 0), expand=True)
-
-    cancel_frame = tk.Frame(root, bg=BG)
-    cancel_frame.pack(fill="x", padx=24, pady=(0, 16))
-
-    tk.Button(
-        cancel_frame, text="Cancel", command=root.destroy,
-        bg=BTN_BG, fg=FG, font=main_font, relief="flat",
-        padx=16, pady=4, cursor="hand2"
-    ).pack(expand=True)
-
-    root.update_idletasks()
-    w = max(root.winfo_reqwidth(), 340)
-    h = root.winfo_reqheight()
-    x = (root.winfo_screenwidth() - w) // 2
-    y = (root.winfo_screenheight() - h) // 2
-    root.geometry(f"{w}x{h}+{x}+{y}")
-
-    root.protocol("WM_DELETE_WINDOW", root.destroy)
-    root.mainloop()
-
-    return result
-
-
-def show_console(log_file_path):
-    root = tk.Tk()
-    root.title("Amazon Music RPC - Console")
-    root.configure(bg="#1a1a1a")
-    root.geometry("700x420")
-    root.minsize(400, 200)
-
-    mono_font = tkfont.Font(family="Consolas", size=9)
-
-    text = tk.Text(
-        root, bg="#1a1a1a", fg="#cccccc", font=mono_font,
-        insertbackground="#ccc", selectbackground="#3a3a5a",
-        relief="flat", bd=8, wrap="word", state="disabled"
-    )
-    scrollbar = tk.Scrollbar(root, command=text.yview, bg="#2a2a2a", troughcolor="#1a1a1a")
-    text.configure(yscrollcommand=scrollbar.set)
-    scrollbar.pack(side="right", fill="y")
-    text.pack(fill="both", expand=True)
-
-    last_pos = [0]
-
-    def poll_log():
-        try:
-            with open(log_file_path, "r", encoding="utf-8", errors="replace") as f:
-                f.seek(last_pos[0])
-                new_data = f.read()
-                if new_data:
-                    last_pos[0] = f.tell()
-                    text.configure(state="normal")
-                    text.insert("end", new_data)
-                    text.see("end")
-                    text.configure(state="disabled")
-        except FileNotFoundError:
-            pass
-        except Exception:
-            pass
-        root.after(500, poll_log)
-
-    poll_log()
-
-    root.mainloop()
+def show_console(*args, **kwargs):
+    kwargs.setdefault("icon_path", DEFAULT_ICON)
+    return _show_console(*args, **kwargs)
 
 
 def run_from_file(filepath):
-    with open(filepath, "r", encoding="utf-8") as f:
-        request = json.load(f)
+    with open(filepath, "r", encoding="utf-8") as handle:
+        request = json.load(handle)
 
     mode = request.get("mode")
-
     if mode == "choice":
         response = show_choice_picker(
             request["title"],
             request["choices"],
             search_query=request.get("search_query") or request.get("title", ""),
             page_size=request.get("page_size", 5),
+            prompt=request.get("prompt", "No artist found. Select the correct track:"),
+            remember=request.get("remember", True),
         )
     elif mode == "input":
         response = show_input_picker(request["artist"])
     elif mode == "wrongsong":
         response = show_wrong_song_dialog()
+    elif mode == "correction":
+        response = show_correction_dialog(
+            request.get("raw_track") or {}, request.get("track")
+        )
     else:
         response = {}
 
-    with open(filepath, "w", encoding="utf-8") as f:
-        json.dump(response, f)
+    with open(filepath, "w", encoding="utf-8") as handle:
+        json.dump(response, handle)
 
 
 if __name__ == "__main__":
-    if '--console' in sys.argv:
-        idx = sys.argv.index('--console')
-        if idx + 1 < len(sys.argv):
-            show_console(sys.argv[idx + 1])
+    if "--console" in sys.argv:
+        index = sys.argv.index("--console")
+        if index + 1 < len(sys.argv):
+            show_console(sys.argv[index + 1])
     elif len(sys.argv) > 1:
         run_from_file(sys.argv[1])

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,12 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+import sys
+
+
+def pytest_ignore_collect(collection_path, config):
+    parts = {part.casefold() for part in collection_path.parts}
+    if "macos" in parts and "tests" in parts and sys.platform != "darwin":
+        return True
+    if "windows" in parts and "tests" in parts and sys.platform != "win32":
+        return True
+    return None

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
-Amazon Music RPC v5 keeps the executable entry point small and separates application state, owned work, windows, commands, and Discord lifecycle from the playback pipeline.
+Amazon Music RPC v5 keeps platform entry points small and separates native metadata, startup, and packaging from platform-neutral playback decisions. Windows remains the stable architecture; the macOS implementation is a beta prototype.
 
-## Runtime Boundaries
+## Windows Runtime Boundaries
 
 `Windows/main.py` starts `desktop_runtime.main()`. The desktop runtime composes these boundaries:
 
@@ -12,11 +12,32 @@ Amazon Music RPC v5 keeps the executable entry point small and separates applica
 - `RpcController` owns the Discord RPC lifecycle.
 - `WindowController` owns Settings and Diagnostics subprocesses and monitors auto-saved config changes.
 - `CommandController` maps tray and integration commands to explicit handlers.
-- `StructuredLogTee` preserves the readable rotating console log and emits a redacted JSONL event stream.
+- `StructuredLogTee` preserves the rotating console log and emits a redacted JSONL event stream.
 
-The playback pipeline remains in `desktop_runtime.py` because source precedence, timing correction, scrobbling eligibility, privacy, artwork, and Discord updates form one stateful loop. New UI or transport behavior should enter through a controller instead of adding an independent global thread.
+The stateful Windows source/presence loop remains in `desktop_runtime.py`. New UI or transport behavior should enter through a controller instead of adding an independent global thread.
 
-## Metadata Precedence
+## macOS Beta Runtime Boundaries
+
+`MacOS/main.py` starts the PySide menu-bar application and composes:
+
+- `MacRuntime`, which owns metadata polling, Discord presence, artwork, privacy state, and scrobbler lifecycles.
+- `RuntimeDependencies`, which keeps native readers and outbound services replaceable in tests.
+- `MacOS/amazon_devtools.py`, which owns validated launch/restart, listener ownership, CDP target validation, and bounded metadata evaluation.
+- `MacOS/media_reader.py` plus `amazon_music_now_playing.js`, which provide the read-only owner-validated Now Playing fallback.
+- `MacOS/config.py`, which owns atomic config updates, Keychain-backed secrets, redaction, and the optional per-user LaunchAgent.
+- `MacOS/ui.py`, which owns the menu-bar item, Settings, Diagnostics, file pickers, and update actions.
+- `MacOS/single_instance.py`, which owns a per-user file lock and owner-only Unix command socket.
+- `MacOS/updater.py`, which accepts only bounded GitHub release metadata and checksum-verified DMG assets.
+
+The menu bar, runtime, Settings, and Diagnostics share one Qt application. Blocking metadata, network, and file work must remain outside the UI thread and have bounded timeout/shutdown paths.
+
+## Shared Playback Behavior
+
+`Shared/playback.py` is the pure-Python behavior layer consumed by Windows and macOS. It owns track normalization, privacy keyword matching, process-name/game-mode matching, remembered corrections, custom-art matching, and scrobble eligibility. The shared threshold is at least 30 seconds played plus either half of a known duration or 240 seconds.
+
+Platform-native metadata and lifecycle code may differ, but user-visible rules must not drift. A fundamental behavior change must update the shared implementation or deliberately update both platform paths and their tests. A UI rewrite or runtime split that changes behavior must be carried across Windows and macOS unless the difference is intrinsically platform specific.
+
+## Windows Metadata Precedence
 
 1. Amazify integration, when installed and actively connected.
 2. Enhanced Amazon metadata through a validated local DevTools target.
@@ -26,18 +47,32 @@ The playback pipeline remains in `desktop_runtime.py` because source precedence,
 
 Each lower source is a fallback. It must not overwrite a complete higher-priority snapshot with older metadata.
 
-## Process Model
+## macOS Metadata Precedence
 
-The tray and playback loop live in the main process. Settings and Diagnostics are separate WebView2 subprocesses so a UI failure does not terminate playback. The updater reuses the frozen executable in a dedicated helper mode after the main process exits. Amazify communication uses a token-authenticated loopback bridge.
+1. Enhanced Amazon metadata through a validated local DevTools target.
+2. Read-only macOS Now Playing data owned exactly by `com.amazon.music`.
+3. Optional Deezer/iTunes lookup for missing public artwork or related metadata.
+
+If Amazon Music is already running without a DevTools listener, the runtime reports that a restart is required. Restarting Amazon Music must remain an explicit user action; it is never an implicit metadata fallback. A lower source must not overwrite a complete current DevTools snapshot.
+
+## Process Models
+
+On Windows, the tray and playback loop live in the main process. Settings and Diagnostics are separate WebView2 subprocesses so a UI failure does not terminate playback. The updater reuses the frozen executable in a dedicated helper mode after the main process exits. Amazify communication uses a token-authenticated loopback bridge.
+
+On macOS, the menu bar and playback runtime share one process. The prototype can start the validated Amazon Music executable with loopback metadata flags when Amazon Music is not running; replacing an already-running normal session requires an explicit enhanced-metadata restart. It invokes `/usr/bin/osascript` as a bounded fallback probe and never attaches to or injects into Amazon Music. A mode-`0600` Unix socket accepts only a small allowlist of same-user single-instance commands.
 
 ## Shutdown
 
-Shutdown first stops accepting commands, requests supervised task cancellation, closes child windows and local bridges, disconnects Discord, joins owned non-daemon workers, and then releases the single-instance mutex. A new background task must either be owned by `TaskSupervisor` or expose an explicit stop-and-join lifecycle.
+Windows shutdown first stops accepting commands, requests supervised task cancellation, closes child windows and local bridges, disconnects Discord, joins owned non-daemon workers, and releases the single-instance mutex. A new background task must either be owned by `TaskSupervisor` or expose an explicit stop-and-join lifecycle.
+
+macOS shutdown stops polling and outbound services, clears Discord presence, closes Qt UI state, removes the owned Unix command socket, and releases the file lock. Ordinary Amazon Music RPC shutdown does not terminate Amazon Music.
 
 ## Change Rules
 
-- Keep data crossing controller boundaries typed and bounded.
-- Keep config writes atomic and auto-saved through the existing config API.
+- Keep data crossing controller/runtime boundaries typed and bounded.
+- Keep config writes atomic and auto-saved through the platform config API.
 - Do not log tokens, raw lookup queries, or unredacted config payloads.
 - Add network destinations to `network-endpoints.md` and expose a user control when traffic is optional.
 - Update `threat-model.md` when a trust boundary, local listener, updater path, or secret store changes.
+- Preserve the explicit macOS restart boundary and exact Amazon bundle/listener/target validation.
+- Keep platform-neutral playback rules in `Shared/` and cover fundamental changes on both platforms.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Amazon Music RPC v5 keeps platform entry points small and separates native metadata, startup, and packaging from platform-neutral playback decisions. Windows remains the stable architecture; the macOS implementation is a beta prototype.
+Amazon Music RPC v5 keeps platform entry points small and separates native metadata, startup, and packaging from platform-neutral playback decisions. Windows remains the published stable platform; the macOS implementation is an active beta maintained alongside it on `master`.
 
 ## Windows Runtime Boundaries
 
@@ -59,7 +59,7 @@ If Amazon Music is already running without a DevTools listener, the runtime repo
 
 On Windows, the tray and playback loop live in the main process. Settings and Diagnostics are separate WebView2 subprocesses so a UI failure does not terminate playback. The updater reuses the frozen executable in a dedicated helper mode after the main process exits. Amazify communication uses a token-authenticated loopback bridge.
 
-On macOS, the menu bar and playback runtime share one process. The prototype can start the validated Amazon Music executable with loopback metadata flags when Amazon Music is not running; replacing an already-running normal session requires an explicit enhanced-metadata restart. It invokes `/usr/bin/osascript` as a bounded fallback probe and never attaches to or injects into Amazon Music. A mode-`0600` Unix socket accepts only a small allowlist of same-user single-instance commands.
+On macOS, the menu bar and playback runtime share one process. The beta runtime can start the validated Amazon Music executable with loopback metadata flags when Amazon Music is not running; replacing an already-running normal session requires an explicit enhanced-metadata restart. It invokes `/usr/bin/osascript` as a bounded fallback probe and never attaches to or injects into Amazon Music. A mode-`0600` Unix socket accepts only a small allowlist of same-user single-instance commands.
 
 ## Shutdown
 

--- a/docs/macos-beta.md
+++ b/docs/macos-beta.md
@@ -1,0 +1,150 @@
+# macOS Beta Prototype
+
+The `beta/MacOS` branch contains the first native macOS prototype of Amazon Music RPC. Windows on `master` remains the stable release. The macOS build is a menu-bar app for Amazon's official `/Applications/Amazon Music.app`; it is not a browser wrapper and does not alter the Amazon application bundle.
+
+## Implemented Beta Features
+
+- Discord Rich Presence payloads with title, artist, album, artwork, playback state, timer, status-display choice, and an optional song link
+- Enhanced Amazon metadata through a validated local Chromium DevTools target
+- Read-only macOS Now Playing fallback when DevTools is disabled or unavailable
+- Last.fm and ListenBrainz configuration, now-playing submission, and the shared scrobble threshold
+- Private session, keyword privacy filters, game-mode process filters, remembered track corrections, and custom album art
+- Configurable Amazon/Deezer song links and optional Deezer/iTunes artwork lookup
+- Menu-bar controls, Settings, Diagnostics, redacted network history, update checks, and optional start at login
+- A PyInstaller `.app` and DMG containing the app plus an Applications shortcut
+
+These code paths have automated coverage, but the first development Mac did not have Discord installed. Live Discord IPC and live Last.fm/ListenBrainz submissions have not yet been verified end to end. Visual behavior, reconnect handling, Keychain prompts, login items, and a clean-machine drag install also require manual testing before the beta can be promoted.
+
+## Metadata Order
+
+1. **Validated DevTools metadata** is primary when enhanced metadata is enabled. It can provide the richest Amazon-native title, artist, album, artwork, playback state, position, duration, and link data.
+2. **macOS Now Playing** is the fallback. It accepts an active session only when the owner is exactly `com.amazon.music`, is read-only, and does not send playback commands.
+3. **Optional Deezer/iTunes lookup** can fill artwork or other missing public metadata according to the user's network settings.
+
+The official Amazon Music app does not expose DevTools during a normal launch. If it is already running normally when enhanced metadata is enabled, Amazon Music RPC reports that a restart is required. The user must explicitly choose **Restart Amazon Music with DevTools** once for that running session. The app then terminates only processes whose executable resolves inside the validated Amazon installation and launches its exact executable with:
+
+```text
+--remote-debugging-address=127.0.0.1
+--remote-debugging-port=<random private high port>
+```
+
+No shortcut, preference, browser profile, login data, or file inside Amazon Music is changed. If Amazon Music is later started normally before Amazon Music RPC, another explicit restart can be required. Closing Amazon Music or relaunching it normally removes the debugging listener. Turning off **Enable enhanced metadata** stops RPC connections but does not change the already-running Amazon process; use the separately confirmed **Disable listener & reopen normally** action when the listener itself must be removed.
+
+## DevTools Security Boundary
+
+DevTools can inspect an authenticated renderer, so the beta treats it as a narrow privileged local interface:
+
+- The Amazon app must resolve to `/Applications/Amazon Music.app`, declare bundle identifier `com.amazon.music` and executable `Amazon Music`, and match Amazon's Team ID/signing authority.
+- The selected port is random, kept in memory, and restricted to `49152–60999` on `127.0.0.1`.
+- Every listener PID is resolved to an executable inside that validated Amazon-identity bundle. Listener identity is checked before target discovery and rechecked before evaluation.
+- HTTP discovery is limited to `/json`, `/json/list`, and `/json/version`, with bounded responses.
+- The accepted target must be a page on an exact supported `https://music.amazon.<region>` host or Amazon's exact legacy `https://www.amazon.<region>/morpho/webapp` path. Credentials, unexpected ports, lookalike domains, fragments, and untrusted WebSocket paths are rejected.
+- The WebSocket must return to loopback on the same selected port and match the discovered page target ID. Handshakes, frames, and JSON results are size bounded.
+- The client sends a single bounded `Runtime.evaluate` script that reads visible transport metadata. It does not call the CDP cookie, storage, request-header, network-body, download, or debugger APIs.
+- Returned links and artwork are independently allowlisted and sanitized before use. Failed launches are stopped, and process termination is limited to revalidated Amazon executable paths.
+
+The CEF listener itself has no Amazon Music RPC authentication. Any other process running locally as the same user may be able to discover and connect to it while enhanced metadata is active. Loopback prevents remote-network access but does not protect against already-running local software. Use fallback-only mode, close Amazon Music, or relaunch Amazon Music normally when this local exposure is not acceptable.
+
+The implementation never reads Amazon Music cookies, LevelDB/IndexedDB, browser storage, offline state, logs, or account files. `/tmp/AmazonMusic.ipc` and Amazon's Qt single-instance sockets are explicitly rejected integration surfaces.
+
+## macOS Permissions
+
+Normal presence and metadata operation is not expected to request any of these macOS privacy permissions:
+
+- Accessibility or Input Monitoring
+- Automation/Apple Events
+- Screen Recording
+- Full Disk Access
+- Media & Apple Music
+- Camera, Microphone, Contacts, or Location
+- Local Network
+
+The Now Playing fallback invokes `/usr/bin/osascript` to read a local framework object; it does not automate Amazon Music or System Events. Discord uses a local Unix-domain IPC socket, and DevTools uses loopback rather than a broadcast-capable local network.
+
+Conditional system interaction is limited to:
+
+- **Keychain:** macOS may ask to unlock the login Keychain or approve access when Last.fm or ListenBrainz credentials are saved or read.
+- **Start at login:** enabling it writes a per-user LaunchAgent. macOS may show a Background Items notification, and the user can disable it in **System Settings > General > Login Items**.
+- **File pickers:** settings import/export and diagnostics export access only the file or destination the user selects. macOS may show a Files and Folders prompt if the chosen location is TCC-protected.
+- **Outbound Internet:** enabled update checks, artwork providers, and scrobblers make HTTPS requests; a non-sandboxed direct-download app does not need a separate network entitlement.
+
+The prototype requests no special entitlements and is not App Sandbox enabled. See [MacOS/PERMISSIONS.md](../MacOS/PERMISSIONS.md) for the complete signing and permission analysis.
+
+## Local Data
+
+Non-secret state is stored under:
+
+```text
+~/Library/Application Support/AmazonMusicRPC/
+```
+
+This includes `config.json`, diagnostics, logs, redacted network history, the single-instance lock, and an owner-only Unix command socket. Files containing app state are created with restrictive per-user permissions where supported.
+
+Sensitive values are generic-password items in the user's login Keychain:
+
+```text
+service: io.github.eripum9.amazon-music-rpc
+accounts: lastfm_api_secret, lastfm_session_key, listenbrainz_token
+```
+
+The optional login item is:
+
+```text
+~/Library/LaunchAgents/io.github.eripum9.amazon-music-rpc.plist
+```
+
+Secrets are omitted from `config.json` and redacted from diagnostics/exports.
+
+## Run From Source
+
+Python 3.12 is the development baseline:
+
+```bash
+git clone https://github.com/eripum9/Amazon-Music-Discord-RPC.git
+cd Amazon-Music-Discord-RPC
+git checkout beta/MacOS
+python3.12 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r MacOS/requirements.txt
+python -m MacOS.main
+```
+
+Run automated checks from the repository root:
+
+```bash
+python -m pip install -r Windows/requirements-dev.txt
+python -m pytest MacOS/tests Shared/tests
+python -m compileall -q MacOS Shared
+```
+
+## Build And Drag Install
+
+On macOS, install the build requirements and create both artifacts:
+
+```bash
+source .venv/bin/activate
+python -m pip install -r MacOS/requirements-build.txt
+MacOS/scripts/build_app.sh
+MacOS/scripts/create_dmg.sh
+```
+
+The build writes:
+
+```text
+MacOS/dist/Amazon Music RPC.app
+MacOS/dist/Amazon-Music-RPC.dmg
+MacOS/dist/Amazon-Music-RPC.dmg.sha256
+```
+
+To install, open the DMG, drag **Amazon Music RPC** onto the **Applications** shortcut shown in the DMG, wait for the copy, eject the DMG, and launch `/Applications/Amazon Music RPC.app`.
+
+The target architecture is inherited from the Python interpreter and installed binary wheels. The declared deployment target is macOS 12.0, while the first development host was Intel macOS 15.7.7; Apple-silicon and older-system compatibility require separate tests.
+
+With no `MACOS_CODESIGN_IDENTITY`, the build is ad-hoc signed for local testing. This repository does not claim that a beta DMG has been Developer ID signed or notarized. Do not redistribute a local prototype as an official release.
+
+## Shared Windows/macOS Behavior
+
+Platform-native metadata, permissions, startup, and packaging stay separate. User-visible playback decisions live in `Shared/playback.py`: track normalization, privacy matching, process-name/game-mode matching, remembered corrections, custom-art matching, and the scrobble threshold of at least 30 seconds plus either 50% of a known duration or 240 seconds.
+
+A fundamental behavior change must update the shared module or deliberately update and test both platform implementations. The macOS beta must not gain a different privacy or scrobbling interpretation from the stable Windows build merely because its native metadata source is different.

--- a/docs/macos-beta.md
+++ b/docs/macos-beta.md
@@ -1,6 +1,6 @@
-# macOS Beta Prototype
+# macOS Beta
 
-The `beta/MacOS` branch contains the first native macOS prototype of Amazon Music RPC. Windows on `master` remains the stable release. The macOS build is a menu-bar app for Amazon's official `/Applications/Amazon Music.app`; it is not a browser wrapper and does not alter the Amazon application bundle.
+macOS is an active beta development target maintained on `master`. Windows remains the only published stable release, and v5.0.1 does not include a macOS artifact. The macOS build is a menu-bar app for Amazon's official `/Applications/Amazon Music.app`; it is not a browser wrapper and does not alter the Amazon application bundle.
 
 ## Implemented Beta Features
 
@@ -68,7 +68,7 @@ Conditional system interaction is limited to:
 - **File pickers:** settings import/export and diagnostics export access only the file or destination the user selects. macOS may show a Files and Folders prompt if the chosen location is TCC-protected.
 - **Outbound Internet:** enabled update checks, artwork providers, and scrobblers make HTTPS requests; a non-sandboxed direct-download app does not need a separate network entitlement.
 
-The prototype requests no special entitlements and is not App Sandbox enabled. See [MacOS/PERMISSIONS.md](../MacOS/PERMISSIONS.md) for the complete signing and permission analysis.
+The beta requests no special entitlements and is not App Sandbox enabled. See [MacOS/PERMISSIONS.md](../MacOS/PERMISSIONS.md) for the complete signing and permission analysis.
 
 ## Local Data
 
@@ -102,7 +102,7 @@ Python 3.12 is the development baseline:
 ```bash
 git clone https://github.com/eripum9/Amazon-Music-Discord-RPC.git
 cd Amazon-Music-Discord-RPC
-git checkout beta/MacOS
+git checkout master
 python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
@@ -141,7 +141,7 @@ To install, open the DMG, drag **Amazon Music RPC** onto the **Applications** sh
 
 The target architecture is inherited from the Python interpreter and installed binary wheels. The declared deployment target is macOS 12.0, while the first development host was Intel macOS 15.7.7; Apple-silicon and older-system compatibility require separate tests.
 
-With no `MACOS_CODESIGN_IDENTITY`, the build is ad-hoc signed for local testing. This repository does not claim that a beta DMG has been Developer ID signed or notarized. Do not redistribute a local prototype as an official release.
+With no `MACOS_CODESIGN_IDENTITY`, the build is ad-hoc signed for local testing. This repository does not claim that a beta DMG has been Developer ID signed or notarized. Do not redistribute a local beta build as an official release.
 
 ## Shared Windows/macOS Behavior
 

--- a/docs/macos-integration-research.md
+++ b/docs/macos-integration-research.md
@@ -1,16 +1,16 @@
 # macOS Integration Research
 
-Status: static analysis and a read-only live playback proof of concept are complete. A full macOS application runtime has not been built yet.
+Status: bundle research and a read-only Now Playing proof of concept are complete. A native beta runtime, validated DevTools transport, settings/diagnostics UI, shared playback behavior, `.app`, and drag-install DMG pipeline are implemented on `beta/MacOS`. Live Discord Rich Presence and live Last.fm/ListenBrainz submissions have not yet been tested end to end.
 
 ## Scope And Safety
 
-The installed application was found at `/Applications/Amazon Music.app`. A read-only working copy was made in a uniquely named directory under `/tmp` for bundle and binary inspection. The application bundle and extracted binaries are not stored in this repository.
+Amazon now provides an official macOS desktop app. The installed application was found at `/Applications/Amazon Music.app`. A read-only working copy was made in a uniquely named directory under `/tmp` for bundle and binary inspection; neither that copy nor extracted Amazon binaries are stored in this repository.
 
-The live checks intentionally avoided printing or persisting the current track, account data, cookies, or tokens.
+The research avoided retaining current-track values, account data, cookies, tokens, browser storage, or authenticated application files. The prototype does not modify or inject code into Amazon Music.
 
 ## Verified Bundle Findings
 
-The installed application reports:
+The inspected application reported:
 
 - Bundle identifier: `com.amazon.music`
 - Version: `9.5.2` (`9.5.2.2478`)
@@ -19,100 +19,92 @@ The installed application reports:
 - Custom URL scheme: `amazoncloudplayer`
 - Approximate copied bundle size: 459 MB
 
-The main executable links the following components relevant to an RPC integration:
+Relevant linked components included Qt 4.8 (`QtCore`, `QtGui`, and `QtNetwork`), Chromium Embedded Framework compatibility version `791.0.31`, a weak link to Apple's `MediaPlayer.framework`, and separate renderer/GPU helper applications.
 
-- Qt 4.8 (`QtCore`, `QtGui`, and `QtNetwork`)
-- Chromium Embedded Framework, compatibility version `791.0.31`
-- Apple's `MediaPlayer.framework` as a weak-linked framework
-- Separate renderer and GPU helper applications
+The signature metadata includes hardened-runtime allowances appropriate to Amazon's embedded Chromium/JIT code. Amazon Music RPC does not copy those entitlements, embed Chromium, inject code, or attach a debugger. The copied research bundle contained an updater-generated `update.ini` outside the sealed resources, so deep verification of that copy reported an extra file; that observation alone did not establish that the installed application was modified.
 
-The signature metadata includes hardened-runtime allowances for JIT execution and debugging-related behavior, which is consistent with an embedded Chromium application. The copied bundle also contained an updater-generated `update.ini` file that was not part of the sealed resources, so deep verification of the copy reported that extra file. This result alone does not establish that the installed application was modified.
+## Selected Metadata Architecture
 
-## Candidate Metadata Interfaces
+### 1. Chromium DevTools Protocol (Primary)
 
-### 1. macOS Now Playing (Verified)
+Launching the embedded CEF runtime with a loopback debugging flag exposed a DevTools target, confirming that CDP can provide the richer Amazon-native metadata needed for album artwork, exact timing, links, and playback state. A normal Amazon Music launch has no listener.
 
-This is the recommended primary metadata path because it does not require attaching to or modifying Amazon Music. Live testing on macOS 15.7.7 confirmed that the active Now Playing client identifies itself as `com.amazon.music`.
+The beta therefore uses DevTools first when enhanced metadata is enabled. If Amazon Music is already open normally, the application reports `restart_required`; the user must explicitly choose a one-time restart for that running session. No persistent shortcut, preference, browser profile, or Amazon application file is changed. A normal relaunch removes the listener.
 
-Potentially useful fields include:
+The implementation narrows CDP's inherently sensitive authenticated-renderer access:
+
+- It accepts only the official bundle at `/Applications/Amazon Music.app`, exact identifier/executable, Amazon Team ID, and signing authority.
+- It chooses an in-memory port in `49152–60999`, passes `--remote-debugging-address=127.0.0.1`, and never binds Amazon Music RPC itself to a TCP listener.
+- It identifies all listener PIDs with `lsof` and accepts only executables resolving inside the validated Amazon bundle. Ownership is checked before discovery and again before evaluation.
+- Discovery requests are limited to `/json`, `/json/list`, and `/json/version`; HTTP, WebSocket handshake, frame, and JSON sizes are bounded.
+- Page URLs must be exact supported HTTPS `music.amazon.<region>` hosts or the exact legacy Amazon Morpho webapp path. Credentials, non-default HTTPS ports, lookalike hosts, untrusted WebSocket paths, query-bearing WebSocket URLs, and mismatched target IDs are rejected.
+- Only a bounded `Runtime.evaluate` expression reads visible transport metadata. The code does not request cookies, browser storage, request headers/bodies, downloads, or debugging primitives.
+- Track links and artwork pass independent exact-host/scheme validation. Failed launches are terminated, and restart/stop actions signal only revalidated Amazon executable paths.
+
+Loopback blocks remote-network connections, but the CEF listener has no application-level authentication. Another local process running as the same user could potentially discover it while enhanced metadata is active. Turning off the RPC setting stops this app from connecting but does not reconfigure the already-running Amazon process. Users who do not accept that local exposure can use the explicitly confirmed **Disable listener & reopen normally** action, or close/relaunch Amazon Music normally, then remain in Now Playing fallback mode. See [macos-beta.md](macos-beta.md) for the user-facing boundary.
+
+### 2. macOS Now Playing (Verified Fallback)
+
+Live testing on Intel macOS 15.7.7 confirmed that the active Now Playing owner identifies itself as `com.amazon.music`. The fallback can provide:
 
 - Track title, artist, and album
-- Duration and elapsed playback time
-- Playback rate, which can distinguish playing from paused
-- Artwork data when exposed by the active Now Playing client
-- Owning application or bundle identifier, which must be checked against `com.amazon.music`
+- Duration and calculated elapsed playback time
+- Playback rate, which distinguishes playing from paused
+- Artwork descriptors when exposed by the active Now Playing client
+- The owning bundle identifier, which is required to equal `com.amazon.music`
 
-On recent macOS versions, direct use of the private `MediaRemote` C API is entitlement-restricted. The proof of concept instead loads the local `MediaRemote.framework` classes through JavaScript for Automation and `/usr/bin/osascript`, then reads `MRNowPlayingRequest`.
+On recent macOS versions, direct use of the private `MediaRemote` C API is entitlement restricted. The fallback loads local `MediaRemote.framework` classes through JavaScript for Automation and `/usr/bin/osascript`, then reads `MRNowPlayingRequest`. It does not send Apple Events to Amazon Music or control playback.
 
-The live probe verified:
+The live probe verified exact owner validation, title/artist/album availability, duration, playing/paused state, and `MRContentItemMetadata.calculatedPlaybackPosition`. Position advanced by approximately 2.02 seconds during a two-second sample. Artwork MIME type, dimensions, identifier, and local/remote descriptors were present, but the synchronous object did not expose bounded image bytes or a directly usable HTTPS URL. The implementation therefore leaves fallback artwork empty so the existing optional Deezer/iTunes lookup can fill it.
 
-- Exact ownership validation through `com.amazon.music`
-- Title, artist, and album availability
-- Duration and playing/paused state through playback rate
-- Accurate position through `MRContentItemMetadata.calculatedPlaybackPosition`
-- Position advancement of approximately 2.02 seconds during a two-second sample
-- Artwork availability, MIME type, dimensions, identifier, and local/remote artwork descriptors
+The fallback consists of:
 
-The synchronous artwork object did not expose image bytes, and its identifier was not a directly usable HTTPS URL. The initial implementation therefore leaves artwork empty so the existing bounded Deezer/iTunes lookup path can provide it. Artwork retrieval can be investigated separately without blocking metadata polling.
+- `MacOS/amazon_music_now_playing.js`, which serializes the local Now Playing state without playback controls
+- `MacOS/media_reader.py`, which invokes `/usr/bin/osascript` without a shell, enforces time/output limits, validates `com.amazon.music`, sanitizes every field, and returns the common track shape
 
-The bundled fallback proof of concept is split into:
+Three consecutive live reads completed in approximately 1.83–2.56 seconds, retained track identity, and reported non-decreasing positions. A four-second timeout leaves margin for this polling fallback.
 
-- `MacOS/amazon_music_now_playing.js`, which reads and serializes the local Now Playing state without playback controls
-- `MacOS/media_reader.py`, which invokes the probe without a shell, enforces a timeout and output-size limit, validates the Amazon bundle identifier, sanitizes fields, and returns the existing track dictionary shape
+### Deferred Persistent Adapter Research
 
-Three consecutive live reads completed in approximately 1.83 to 2.56 seconds, retained the same track identity, and reported a non-decreasing position. A four-second timeout leaves margin for this polling fallback.
+The BSD-3-Clause [mediaremote-adapter](https://github.com/ungive/mediaremote-adapter) was built from source in a temporary directory and returned a read-only Amazon-owned event stream, including playback and artwork metadata. It uses an entitled system host and private-framework/dynamic-loading behavior that would require license notices, a separate security review, compatibility testing, and bounded artwork handling.
 
-#### Recommended Production Event Stream
+It is not bundled in the beta. The current hierarchy is validated DevTools first and the zero-install JXA Now Playing reader second. Adapter adoption should be reconsidered only if polling reliability justifies the additional private-framework and supply-chain surface.
 
-The open-source [mediaremote-adapter](https://github.com/ungive/mediaremote-adapter) was also built from source in a temporary directory and exercised against the playing Amazon Music instance. Its read-only stream returned the `com.amazon.music` owner, playback state, text metadata, duration, timestamp, playback rate, and artwork MIME metadata. No account or track values were retained in the research output.
+## Rejected Interfaces
 
-The adapter uses the entitled system `/usr/bin/perl` host to load a bundled helper framework, avoiding the macOS 15.4 entitlement failure that affects ordinary third-party MediaRemote clients. Its persistent JSON event stream avoids repeated `osascript` startup and can deliver artwork bytes in a later update. It is BSD-3-Clause licensed, but its private-framework dependency and dynamic-loading design still require security review, bundled license notices, and macOS compatibility tests.
+### Accessibility Or Window Scraping
 
-The recommended hierarchy is therefore:
+Accessibility is fragile, exposes a broader UI surface, and requires a TCC permission that the selected metadata paths do not need. The beta does not request Accessibility, Automation, Screen Recording, Input Monitoring, Full Disk Access, or Media & Apple Music permission.
 
-1. A bundled, read-only mediaremote-adapter event stream for production metadata and eventual artwork.
-2. The current JXA reader as a zero-install polling fallback.
-3. Existing external artwork lookup when the system does not provide artwork bytes.
+### Amazon Internal IPC And Account Storage
 
-This route uses private implementation details and therefore needs a compatibility fallback and explicit testing on supported macOS releases.
+`/tmp/AmazonMusic.ipc` uses a proprietary Boost.Asio/CEF protocol, while the per-instance Qt local-peer socket is an internal single-instance channel. Neither is a supported metadata API.
 
-### 2. Chromium DevTools Protocol
+Amazon Music's Application Support directory can contain cookies, LevelDB/IndexedDB, local storage, offline state, player configuration, and logs. Those authenticated/account-linked files are explicitly outside the integration boundary and must not be read for metadata.
 
-The embedded CEF runtime makes a loopback Chromium DevTools connection plausible. It could provide richer Amazon Music page state, including artwork URLs and exact timing, similar to the current Windows enhanced-metadata path.
+## Implemented Prototype Boundaries
 
-An earlier transient launch did expose CEF DevTools on loopback when the debugging flag was supplied, confirming that CDP is possible. A normal launch has no debugging listener. Because CDP exposes the authenticated renderer and is unnecessary for core metadata, it should remain an opt-in diagnostic experiment rather than the default integration.
+- Non-secret config, diagnostics, and logs: `~/Library/Application Support/AmazonMusicRPC/`
+- Last.fm/ListenBrainz secret service in login Keychain: `io.github.eripum9.amazon-music-rpc`
+- Optional login item: `~/Library/LaunchAgents/io.github.eripum9.amazon-music-rpc.plist`
+- No expected Accessibility, Automation, Screen Recording, Input Monitoring, Full Disk Access, Media & Apple Music, or Local Network prompt
+- Conditional Keychain access, background-item notification, and user-selected file access only
+- Platform-neutral privacy, corrections, process matching, custom art, track normalization, and scrobble threshold in `Shared/playback.py`
 
-If supported, the implementation must preserve the existing security boundaries:
+## Remaining Manual Tests
 
-- Use a random high port bound to loopback only.
-- Keep the port in memory rather than in shared configuration.
-- Accept only page targets whose parsed HTTPS hostname is an approved `music.amazon.*` host.
-- Reject credentials, unexpected ports, non-HTTPS targets, and lookalike domains.
-- Stop or detach cleanly without leaving a debugging endpoint exposed.
-
-### 3. Accessibility Or Window Metadata
-
-macOS Accessibility could provide a limited fallback when system Now Playing and CEF metadata are unavailable. It may require user approval and is likely to be more fragile, so it should not be the primary integration.
-
-### Rejected Internal Interfaces
-
-The application creates `/tmp/AmazonMusic.ipc` using a proprietary Boost.Asio/CEF message protocol and also uses a per-instance Qt local-peer socket. These are internal browser/renderer and single-instance channels rather than supported metadata APIs.
-
-Amazon Music's Application Support directory contains cookies, LevelDB/IndexedDB data, local storage, offline state, player configuration, and logs. Those files can contain authenticated or account-linked state, are often locked while the app is running, and must not be used as a metadata integration surface.
-
-## Remaining Tests
-
-1. Verify a manual pause/resume transition without having the test control playback.
-2. Verify track-change behavior and position reset across at least two tracks.
-3. Integrate and security-review the persistent adapter stream, including clean shutdown and restart behavior.
-4. Validate delayed artwork events and cap decoded artwork size before use.
-5. Build the macOS runtime and connect the normalized reader to Discord RPC.
-6. Update platform claims in `README.md`, `CONTRIBUTING.md`, and the architecture/privacy documentation only when that runtime is usable.
+1. Install Discord and verify presence creation, pause/resume timers, track changes, buttons/artwork, Discord restart/reconnect, and presence clearing.
+2. Verify live Last.fm authentication/now-playing/scrobbling and live ListenBrainz token validation/now-playing/scrobbling without exposing credentials.
+3. Exercise the explicit Amazon restart flow, fallback-only mode, normal relaunch cleanup, and listener-owner rejection.
+4. Test Keychain approval and denial, login-item enable/disable, selected-file import/export, and unexpected TCC prompts on a clean macOS account.
+5. Mount the DMG, drag to Applications, eject, launch the installed copy, verify menu-bar visuals, and test clean uninstall.
+6. Repeat on Apple silicon and older supported macOS versions; the first development host was Intel macOS 15.7.7.
+7. Complete Developer ID signing, notarization, stapling, and clean-machine Gatekeeper validation before describing any public DMG as a distributable release.
 
 ## Research References
 
 - [Apple MPNowPlayingInfoCenter documentation](https://developer.apple.com/documentation/mediaplayer/mpnowplayinginfocenter)
-- [mediaremote-adapter](https://github.com/ungive/mediaremote-adapter), an open-source compatibility approach for newer macOS versions
-- [nowplaying-cli](https://github.com/kirtan-shah/nowplaying-cli), a reference implementation that documents available Now Playing properties
+- [mediaremote-adapter](https://github.com/ungive/mediaremote-adapter)
+- [nowplaying-cli](https://github.com/kirtan-shah/nowplaying-cli)
 
-These projects are research references only. Their licenses and private-framework tradeoffs must be reviewed before adopting code or a runtime dependency.
+External projects remain research references unless their code, license obligations, and private-framework tradeoffs are explicitly adopted and reviewed.

--- a/docs/macos-integration-research.md
+++ b/docs/macos-integration-research.md
@@ -1,0 +1,84 @@
+# macOS Integration Research
+
+Status: preliminary static analysis; live playback inspection is paused until an Amazon Music login is available.
+
+## Scope And Safety
+
+The installed application was found at `/Applications/Amazon Music.app`. A read-only working copy was made in a uniquely named directory under `/tmp` for bundle and binary inspection. The application bundle and extracted binaries are not stored in this repository.
+
+No macOS implementation or documentation claims should be promoted to stable support until live playback behavior has been verified.
+
+## Verified Bundle Findings
+
+The installed application reports:
+
+- Bundle identifier: `com.amazon.music`
+- Version: `9.5.2` (`9.5.2.2478`)
+- Executable architecture: Intel `x86_64`
+- Signature identity: `Developer ID Application: AMZN Mobile LLC (94KV3E626L)`
+- Custom URL scheme: `amazoncloudplayer`
+- Approximate copied bundle size: 459 MB
+
+The main executable links the following components relevant to an RPC integration:
+
+- Qt 4.8 (`QtCore`, `QtGui`, and `QtNetwork`)
+- Chromium Embedded Framework, compatibility version `791.0.31`
+- Apple's `MediaPlayer.framework` as a weak-linked framework
+- Separate renderer and GPU helper applications
+
+The signature metadata includes hardened-runtime allowances for JIT execution and debugging-related behavior, which is consistent with an embedded Chromium application. The copied bundle also contained an updater-generated `update.ini` file that was not part of the sealed resources, so deep verification of the copy reported that extra file. This result alone does not establish that the installed application was modified.
+
+## Candidate Metadata Interfaces
+
+### 1. macOS Now Playing
+
+This is the preferred first experiment because it does not require attaching to or modifying Amazon Music. The weak link to `MediaPlayer.framework` is evidence that the application may publish system media state.
+
+Potentially useful fields include:
+
+- Track title, artist, and album
+- Duration and elapsed playback time
+- Playback rate, which can distinguish playing from paused
+- Artwork data when exposed by the active Now Playing client
+- Owning application or bundle identifier, which must be checked against `com.amazon.music`
+
+On recent macOS versions, direct use of the private `MediaRemote` C API is entitlement-restricted. A small JavaScript for Automation probe can load the local `MediaRemote.framework` classes through `osascript` and read `MRNowPlayingRequest`. The probe executed successfully on this machine, but there was no active Amazon Music metadata to validate before the login pause.
+
+This route uses private implementation details and therefore needs a compatibility fallback and explicit testing on supported macOS releases.
+
+### 2. Chromium DevTools Protocol
+
+The embedded CEF runtime makes a loopback Chromium DevTools connection plausible. It could provide richer Amazon Music page state, including artwork URLs and exact timing, similar to the current Windows enhanced-metadata path.
+
+This remains unverified. A controlled background launch with a high loopback debugging port was started, then intentionally paused before its result was collected so the account can be logged in first.
+
+If supported, the implementation must preserve the existing security boundaries:
+
+- Use a random high port bound to loopback only.
+- Keep the port in memory rather than in shared configuration.
+- Accept only page targets whose parsed HTTPS hostname is an approved `music.amazon.*` host.
+- Reject credentials, unexpected ports, non-HTTPS targets, and lookalike domains.
+- Stop or detach cleanly without leaving a debugging endpoint exposed.
+
+### 3. Accessibility Or Window Metadata
+
+macOS Accessibility could provide a limited fallback when system Now Playing and CEF metadata are unavailable. It may require user approval and is likely to be more fragile, so it should not be the primary integration.
+
+## Next Live Tests
+
+After login is available:
+
+1. Play a known track and capture only the field names and owning bundle identifier exposed by macOS Now Playing.
+2. Verify title, artist, album, duration, elapsed time, artwork availability, and playing/paused transitions.
+3. Retry the CEF loopback launch and inspect `/json/version` and `/json/list` without retaining account data.
+4. Confirm that any CEF target validation accepts Amazon Music and rejects synthetic hostile URLs.
+5. Compare both paths and choose a primary source plus fallback hierarchy.
+6. Only then update platform claims in `README.md`, `CONTRIBUTING.md`, and the architecture/privacy documentation.
+
+## Research References
+
+- [Apple MPNowPlayingInfoCenter documentation](https://developer.apple.com/documentation/mediaplayer/mpnowplayinginfocenter)
+- [mediaremote-adapter](https://github.com/ungive/mediaremote-adapter), an open-source compatibility approach for newer macOS versions
+- [nowplaying-cli](https://github.com/kirtan-shah/nowplaying-cli), a reference implementation that documents available Now Playing properties
+
+These projects are research references only. Their licenses and private-framework tradeoffs must be reviewed before adopting code or a runtime dependency.

--- a/docs/macos-integration-research.md
+++ b/docs/macos-integration-research.md
@@ -1,12 +1,12 @@
 # macOS Integration Research
 
-Status: preliminary static analysis; live playback inspection is paused until an Amazon Music login is available.
+Status: static analysis and a read-only live playback proof of concept are complete. A full macOS application runtime has not been built yet.
 
 ## Scope And Safety
 
 The installed application was found at `/Applications/Amazon Music.app`. A read-only working copy was made in a uniquely named directory under `/tmp` for bundle and binary inspection. The application bundle and extracted binaries are not stored in this repository.
 
-No macOS implementation or documentation claims should be promoted to stable support until live playback behavior has been verified.
+The live checks intentionally avoided printing or persisting the current track, account data, cookies, or tokens.
 
 ## Verified Bundle Findings
 
@@ -30,9 +30,9 @@ The signature metadata includes hardened-runtime allowances for JIT execution an
 
 ## Candidate Metadata Interfaces
 
-### 1. macOS Now Playing
+### 1. macOS Now Playing (Verified)
 
-This is the preferred first experiment because it does not require attaching to or modifying Amazon Music. The weak link to `MediaPlayer.framework` is evidence that the application may publish system media state.
+This is the recommended primary metadata path because it does not require attaching to or modifying Amazon Music. Live testing on macOS 15.7.7 confirmed that the active Now Playing client identifies itself as `com.amazon.music`.
 
 Potentially useful fields include:
 
@@ -42,7 +42,37 @@ Potentially useful fields include:
 - Artwork data when exposed by the active Now Playing client
 - Owning application or bundle identifier, which must be checked against `com.amazon.music`
 
-On recent macOS versions, direct use of the private `MediaRemote` C API is entitlement-restricted. A small JavaScript for Automation probe can load the local `MediaRemote.framework` classes through `osascript` and read `MRNowPlayingRequest`. The probe executed successfully on this machine, but there was no active Amazon Music metadata to validate before the login pause.
+On recent macOS versions, direct use of the private `MediaRemote` C API is entitlement-restricted. The proof of concept instead loads the local `MediaRemote.framework` classes through JavaScript for Automation and `/usr/bin/osascript`, then reads `MRNowPlayingRequest`.
+
+The live probe verified:
+
+- Exact ownership validation through `com.amazon.music`
+- Title, artist, and album availability
+- Duration and playing/paused state through playback rate
+- Accurate position through `MRContentItemMetadata.calculatedPlaybackPosition`
+- Position advancement of approximately 2.02 seconds during a two-second sample
+- Artwork availability, MIME type, dimensions, identifier, and local/remote artwork descriptors
+
+The synchronous artwork object did not expose image bytes, and its identifier was not a directly usable HTTPS URL. The initial implementation therefore leaves artwork empty so the existing bounded Deezer/iTunes lookup path can provide it. Artwork retrieval can be investigated separately without blocking metadata polling.
+
+The bundled fallback proof of concept is split into:
+
+- `MacOS/amazon_music_now_playing.js`, which reads and serializes the local Now Playing state without playback controls
+- `MacOS/media_reader.py`, which invokes the probe without a shell, enforces a timeout and output-size limit, validates the Amazon bundle identifier, sanitizes fields, and returns the existing track dictionary shape
+
+Three consecutive live reads completed in approximately 1.83 to 2.56 seconds, retained the same track identity, and reported a non-decreasing position. A four-second timeout leaves margin for this polling fallback.
+
+#### Recommended Production Event Stream
+
+The open-source [mediaremote-adapter](https://github.com/ungive/mediaremote-adapter) was also built from source in a temporary directory and exercised against the playing Amazon Music instance. Its read-only stream returned the `com.amazon.music` owner, playback state, text metadata, duration, timestamp, playback rate, and artwork MIME metadata. No account or track values were retained in the research output.
+
+The adapter uses the entitled system `/usr/bin/perl` host to load a bundled helper framework, avoiding the macOS 15.4 entitlement failure that affects ordinary third-party MediaRemote clients. Its persistent JSON event stream avoids repeated `osascript` startup and can deliver artwork bytes in a later update. It is BSD-3-Clause licensed, but its private-framework dependency and dynamic-loading design still require security review, bundled license notices, and macOS compatibility tests.
+
+The recommended hierarchy is therefore:
+
+1. A bundled, read-only mediaremote-adapter event stream for production metadata and eventual artwork.
+2. The current JXA reader as a zero-install polling fallback.
+3. Existing external artwork lookup when the system does not provide artwork bytes.
 
 This route uses private implementation details and therefore needs a compatibility fallback and explicit testing on supported macOS releases.
 
@@ -50,7 +80,7 @@ This route uses private implementation details and therefore needs a compatibili
 
 The embedded CEF runtime makes a loopback Chromium DevTools connection plausible. It could provide richer Amazon Music page state, including artwork URLs and exact timing, similar to the current Windows enhanced-metadata path.
 
-This remains unverified. A controlled background launch with a high loopback debugging port was started, then intentionally paused before its result was collected so the account can be logged in first.
+An earlier transient launch did expose CEF DevTools on loopback when the debugging flag was supplied, confirming that CDP is possible. A normal launch has no debugging listener. Because CDP exposes the authenticated renderer and is unnecessary for core metadata, it should remain an opt-in diagnostic experiment rather than the default integration.
 
 If supported, the implementation must preserve the existing security boundaries:
 
@@ -64,16 +94,20 @@ If supported, the implementation must preserve the existing security boundaries:
 
 macOS Accessibility could provide a limited fallback when system Now Playing and CEF metadata are unavailable. It may require user approval and is likely to be more fragile, so it should not be the primary integration.
 
-## Next Live Tests
+### Rejected Internal Interfaces
 
-After login is available:
+The application creates `/tmp/AmazonMusic.ipc` using a proprietary Boost.Asio/CEF message protocol and also uses a per-instance Qt local-peer socket. These are internal browser/renderer and single-instance channels rather than supported metadata APIs.
 
-1. Play a known track and capture only the field names and owning bundle identifier exposed by macOS Now Playing.
-2. Verify title, artist, album, duration, elapsed time, artwork availability, and playing/paused transitions.
-3. Retry the CEF loopback launch and inspect `/json/version` and `/json/list` without retaining account data.
-4. Confirm that any CEF target validation accepts Amazon Music and rejects synthetic hostile URLs.
-5. Compare both paths and choose a primary source plus fallback hierarchy.
-6. Only then update platform claims in `README.md`, `CONTRIBUTING.md`, and the architecture/privacy documentation.
+Amazon Music's Application Support directory contains cookies, LevelDB/IndexedDB data, local storage, offline state, player configuration, and logs. Those files can contain authenticated or account-linked state, are often locked while the app is running, and must not be used as a metadata integration surface.
+
+## Remaining Tests
+
+1. Verify a manual pause/resume transition without having the test control playback.
+2. Verify track-change behavior and position reset across at least two tracks.
+3. Integrate and security-review the persistent adapter stream, including clean shutdown and restart behavior.
+4. Validate delayed artwork events and cap decoded artwork size before use.
+5. Build the macOS runtime and connect the normalized reader to Discord RPC.
+6. Update platform claims in `README.md`, `CONTRIBUTING.md`, and the architecture/privacy documentation only when that runtime is usable.
 
 ## Research References
 

--- a/docs/macos-integration-research.md
+++ b/docs/macos-integration-research.md
@@ -1,12 +1,12 @@
 # macOS Integration Research
 
-Status: bundle research and a read-only Now Playing proof of concept are complete. A native beta runtime, validated DevTools transport, settings/diagnostics UI, shared playback behavior, `.app`, and drag-install DMG pipeline are implemented on `beta/MacOS`. Live Discord Rich Presence and live Last.fm/ListenBrainz submissions have not yet been tested end to end.
+Status: bundle research and a read-only Now Playing proof of concept are complete. A native beta runtime, validated DevTools transport, settings/diagnostics UI, shared playback behavior, `.app`, and drag-install DMG pipeline are maintained on `master`. Live Discord Rich Presence and live Last.fm/ListenBrainz submissions have not yet been tested end to end.
 
 ## Scope And Safety
 
 Amazon now provides an official macOS desktop app. The installed application was found at `/Applications/Amazon Music.app`. A read-only working copy was made in a uniquely named directory under `/tmp` for bundle and binary inspection; neither that copy nor extracted Amazon binaries are stored in this repository.
 
-The research avoided retaining current-track values, account data, cookies, tokens, browser storage, or authenticated application files. The prototype does not modify or inject code into Amazon Music.
+The research avoided retaining current-track values, account data, cookies, tokens, browser storage, or authenticated application files. The macOS implementation does not modify or inject code into Amazon Music.
 
 ## Verified Bundle Findings
 

--- a/docs/network-endpoints.md
+++ b/docs/network-endpoints.md
@@ -5,21 +5,23 @@ Amazon Music RPC does not send logs or config files automatically. This inventor
 | Destination | Purpose | Data | Control |
 | --- | --- | --- | --- |
 | `api.github.com` | Release metadata and automatic update checks | Current app version and standard HTTPS request metadata | **Automatic update checks** |
-| GitHub release asset hosts | Installer and detached SHA256 download after user approval | Requested release asset | Update action; automatic install requires checksum verification |
+| GitHub release asset hosts (`github.com`, validated GitHub asset redirects) | Windows installer or macOS DMG plus detached SHA256 download after user approval | Requested release asset | Update action; automatic download requires checksum verification |
 | `api.deezer.com` | Track matching, artwork, duration, optional Deezer link | Track and artist search text | **Deezer lookup** |
 | `itunes.apple.com` | Artwork and track fallback | Track and artist search text | **iTunes artwork fallback** |
 | Last.fm API endpoints used by `pylast` | Authentication, now-playing, and scrobbling | Enabled account token and track metadata | **Last.fm scrobbling** |
 | ListenBrainz API endpoints used by `liblistenbrainz` | Token validation, now-playing, and scrobbling | Enabled account token and track metadata | **ListenBrainz scrobbling** |
-| Amazon Music regional sites | User-facing track/search links and artwork already supplied by Amazon Music | Browser navigation or Discord artwork URL | Song link and enhanced metadata settings |
+| Exact supported Amazon Music regional HTTPS sites | User-facing track/search links and artwork already supplied by Amazon Music | Browser navigation or Discord artwork URL | Song link and enhanced metadata settings |
 | Remote artwork hosts returned by Amazon, Deezer, or iTunes | Discord artwork rendering | Artwork URL | Metadata/artwork provider controls |
 
-Discord Rich Presence uses the local Discord IPC connection. Discord may then process the presence and remote artwork URLs under Discord’s own service behavior.
+Discord Rich Presence uses local Discord IPC (named-pipe behavior on Windows or a Unix-domain socket on macOS). Discord may then process the presence and remote artwork URLs under Discord's own service behavior. Live macOS Discord connectivity had not been tested when the first beta was built.
 
 ## Local-Only Interfaces
 
-- Enhanced metadata uses `127.0.0.1` on a random high port selected for the current Amazon Music session.
+- Enhanced metadata uses `127.0.0.1` on a random high port selected for the current Amazon Music session. On macOS the range is `49152–60999`; every listener executable must resolve inside the `/Applications/Amazon Music.app` bundle with the validated Amazon identity, and the target must be an exact allowlisted Amazon HTTPS page on the same port.
 - Amazify integration uses a token-authenticated loopback HTTP bridge on its configured local port.
-- Neither local interface is intended to listen on a non-loopback address.
+- The macOS app's single-instance channel is an owner-only Unix socket under `~/Library/Application Support/AmazonMusicRPC/` (or an owner-specific short path under the system temporary directory when required by Unix path limits). It accepts only settings, diagnostics, activate, and quit commands.
+- The macOS Now Playing fallback invokes a local bounded `/usr/bin/osascript` probe and makes no network request.
+- None of these local interfaces is intended to listen on a non-loopback network address. Loopback does not protect the unauthenticated Amazon CEF DevTools endpoint from other software already running as the same local user.
 
 ## Diagnostics History
 

--- a/docs/platform-roadmap.md
+++ b/docs/platform-roadmap.md
@@ -1,17 +1,24 @@
 # Platform Roadmap
 
-Amazon Music RPC targets platforms where Amazon Music has an official app surface that can be supported responsibly. Windows is the sole supported target.
+Amazon Music RPC targets platforms with an official Amazon Music desktop surface that can be integrated without scraping account storage or requiring broad OS permissions. Windows is stable; macOS is an experimental beta.
 
 ## Current Platform Status
 
 | Platform | Status | Branch | Notes |
 | --- | --- | --- | --- |
-| Windows | Stable | `master` | Main supported release target. |
+| Windows | Stable | `master` | Main supported release target and source of the published installer. |
+| macOS | Beta prototype | `beta/MacOS` | Uses Amazon's official macOS app, validated DevTools metadata, and a read-only Now Playing fallback. Not yet a stable or notarized release. |
+
+The macOS prototype implements the menu-bar UI, Discord/scrobbler runtime paths, privacy controls, diagnostics, Keychain-backed secrets, optional login item, `.app`, and drag-install DMG. Its automated tests do not replace live service testing: Discord was not installed on the first development Mac, and live Discord, Last.fm, and ListenBrainz behavior remains a manual beta gate.
+
+Initial work was performed on Intel macOS 15.7.7. The bundle declares macOS 12.0 as its deployment target, but Apple-silicon, older-system, clean-account permission, signing, notarization, and Gatekeeper testing must be completed before stable support is considered.
+
+## Shared Product Behavior
+
+Windows and macOS intentionally share track normalization, privacy matching, game-mode process matching, remembered corrections, custom-art matching, and scrobble eligibility through `Shared/playback.py`. Fundamental user-visible behavior must be implemented and tested for both platforms; only native metadata, OS integration, and packaging should diverge by default.
 
 ## Out Of Scope
 
 Android support is discontinued because its media-session, background-service, and Discord integration were too unstable to maintain as a supported product.
 
-Linux and macOS are out of scope because Amazon Music does not provide official desktop apps for those platforms. Browser, PWA, or unofficial-wrapper approaches should not be treated as supported targets for this project.
-
-If platform conditions change later, support can be reconsidered with a fresh metadata and Discord presence proof-of-concept.
+Linux remains out of scope because Amazon does not provide an official desktop app surface suitable for the same validated integration. Browser, PWA, and unofficial-wrapper approaches are not supported substitutes.

--- a/docs/platform-roadmap.md
+++ b/docs/platform-roadmap.md
@@ -1,15 +1,15 @@
 # Platform Roadmap
 
-Amazon Music RPC targets platforms with an official Amazon Music desktop surface that can be integrated without scraping account storage or requiring broad OS permissions. Windows is stable; macOS is an experimental beta.
+Amazon Music RPC targets platforms with an official Amazon Music desktop surface that can be integrated without scraping account storage or requiring broad OS permissions. Windows is the published stable platform; macOS is an active beta development target and is no longer out of scope.
 
 ## Current Platform Status
 
 | Platform | Status | Branch | Notes |
 | --- | --- | --- | --- |
 | Windows | Stable | `master` | Main supported release target and source of the published installer. |
-| macOS | Beta prototype | `beta/MacOS` | Uses Amazon's official macOS app, validated DevTools metadata, and a read-only Now Playing fallback. Not yet a stable or notarized release. |
+| macOS | Active beta | `master` | Uses Amazon's official macOS app, validated DevTools metadata, and a read-only Now Playing fallback. Covered by macOS CI, but not yet a published stable or notarized release. |
 
-The macOS prototype implements the menu-bar UI, Discord/scrobbler runtime paths, privacy controls, diagnostics, Keychain-backed secrets, optional login item, `.app`, and drag-install DMG. Its automated tests do not replace live service testing: Discord was not installed on the first development Mac, and live Discord, Last.fm, and ListenBrainz behavior remains a manual beta gate.
+The macOS beta implements the menu-bar UI, Discord/scrobbler runtime paths, privacy controls, diagnostics, Keychain-backed secrets, optional login item, `.app`, and drag-install DMG. Its automated tests do not replace live service testing: Discord was not installed on the first development Mac, and live Discord, Last.fm, and ListenBrainz behavior remains a manual beta gate.
 
 Initial work was performed on Intel macOS 15.7.7. The bundle declares macOS 12.0 as its deployment target, but Apple-silicon, older-system, clean-account permission, signing, notarization, and Gatekeeper testing must be completed before stable support is considered.
 

--- a/docs/promotion-kit.md
+++ b/docs/promotion-kit.md
@@ -2,11 +2,11 @@
 
 ## Main Positioning
 
-Spotify-style Discord Rich Presence for Amazon Music on Windows.
+Spotify-style Discord Rich Presence for Amazon Music on Windows and macOS.
 
 ## Short Description
 
-Amazon Music RPC shows your current Amazon Music song, artist, album art, pause state, and live timer on your Discord profile. It also supports Last.fm, ListenBrainz, privacy mode, keyword filters, and a normal Windows installer.
+Amazon Music RPC shows your current Amazon Music song, artist, album art, pause state, and live timer on your Discord profile. It also supports Last.fm, ListenBrainz, privacy mode, and keyword filters. Windows has a normal stable installer; macOS is an active source-build beta and does not yet have an official release artifact.
 
 ## Reddit Post Template
 
@@ -46,7 +46,7 @@ How to Show Amazon Music on Discord Like Spotify
 
 ## Demo Video Description
 
-Amazon Music RPC is an open-source Windows app that shows your Amazon Music now playing status on Discord, including song title, artist, album art, pause state, and live timer.
+Amazon Music RPC is an open-source Windows and macOS app that shows your Amazon Music now playing status on Discord, including song title, artist, album art, pause state, and live timer. Windows is stable; macOS is currently an active beta.
 
 Download: https://github.com/eripum9/Amazon-Music-Discord-RPC/releases/latest
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -2,25 +2,58 @@
 
 ## Scope
 
-This model covers the Windows app, its installer and updater, Amazon Music enhanced metadata, the local Amazify bridge, local settings and logs, optional scrobblers, and official release artifacts.
+This model covers the stable Windows app and its installer/updater, the macOS
+beta app and its DMG updater, Amazon Music enhanced metadata on both platforms,
+the local Amazify bridge, local single-instance channels, settings and logs,
+optional scrobblers, and release artifacts.
 
 ## Protected Assets
 
-- Last.fm session keys and ListenBrainz tokens
+- Last.fm session keys and ListenBrainz tokens in Windows Credential Manager,
+  the DPAPI fallback, or macOS Keychain
 - Discord presence integrity and current playback metadata
 - The installed executable and updater trust decision
 - Local config, logs, and diagnostics exports
 - The user’s Amazon Music session exposed through local DevTools
+- The owner-only macOS single-instance socket and commands accepted through it
 
 ## Trust Boundaries
 
 ### GitHub Release Boundary
 
-The updater accepts metadata and artifacts only from the configured GitHub repository and approved GitHub asset hosts. Redirects, names, sizes, and the detached SHA256 asset are validated before execution. Official artifacts originate from the manually triggered draft-release workflow on the current `master` commit.
+The updaters accept metadata and artifacts only from the configured GitHub
+repository and approved GitHub asset hosts. Redirects, names, and sizes are
+validated. The Windows updater verifies the installer before handing it to the
+operating system. The macOS beta downloads only the exact DMG asset after a
+matching SHA256 has been obtained, verifies the final bytes, and opens the DMG
+for an explicit drag install; it does not replace the installed app silently.
+Official Windows artifacts originate from the manually triggered draft-release
+workflow on the current `master` commit. The local macOS beta build remains an
+ad-hoc-signed prototype unless a release operator explicitly performs the
+documented Developer ID and notarization workflow.
 
 ### Amazon Music DevTools Boundary
 
-Enhanced metadata opens a random reserved loopback port. The app validates the Amazon page URL, exact target identifier, selected port, WebSocket scheme, and listener ownership before reading DOM metadata. Failure returns to local fallback sources instead of attaching to an unrelated listener.
+Enhanced metadata opens a random reserved loopback port. Both implementations
+validate the Amazon page URL, exact target identifier, selected port, WebSocket
+scheme, and listener ownership before reading DOM metadata. Failure returns to
+local fallback sources instead of attaching to an unrelated listener.
+
+On macOS, the integration accepts only `/Applications/Amazon Music.app` with
+the expected bundle identifier, executable name, Amazon Team ID, and signing
+authority. A listener is trusted only when its process executable resolves to
+an allowlisted executable inside that installation, its endpoint is loopback
+and in the private high-port range, and a validated Amazon page target matches.
+Listener ownership is checked before target discovery and again around the
+bounded read-only evaluation. A fresh RPC process may rediscover an existing
+listener only when socket ownership metadata yields one trusted candidate, but
+it does not inspect Amazon's command line, browser profile, cookies, storage, or
+account files.
+
+Restarting an already-running normal Amazon Music session is an explicit user
+action. Disabling attachment does not by itself remove a listener already owned
+by Amazon Music; the user must explicitly relaunch Amazon Music normally (or
+close it) to remove that endpoint.
 
 ### Amazify Localhost Bridge
 
@@ -28,7 +61,19 @@ The Amazify localhost bridge exposes only RPC status and accepted commands requi
 
 ### Secret Storage Boundary
 
-User tokens are stored in Windows Credential Manager and removed from normal config only after a verified round trip. DPAPI-protected local storage is a compatibility fallback. Logs, diagnostics, and normal exports redact or omit known secrets.
+On Windows, user tokens are stored in Credential Manager and removed from
+normal config only after a verified round trip; DPAPI-protected local storage is
+a compatibility fallback. On macOS, scrobbler secrets are generic-password
+items in the user's login Keychain and are omitted from `config.json`.
+Diagnostics and normal exports redact or omit known secrets on both platforms.
+
+### macOS Single-Instance Boundary
+
+The macOS beta uses a file lock plus a Unix-domain command socket. Its app-data
+directory is made owner-only, the socket is mode `0600`, stale socket removal
+requires a socket owned by the current UID, and commands are limited to a small
+allowlist such as opening Settings or Diagnostics and quitting. It does not
+accept arbitrary paths, shell commands, or network clients.
 
 ### Optional Service Boundary
 
@@ -38,19 +83,30 @@ Discord, Last.fm, ListenBrainz, Deezer, iTunes, GitHub, and remote artwork hosts
 
 | Threat | Control |
 | --- | --- |
-| Malicious release redirect or substituted installer | Exact repository/host validation, bounded downloads, mandatory detached SHA256, unique temp path, build attestation |
+| Malicious release redirect or substituted installer/DMG | Exact repository/host validation, bounded downloads, mandatory checksum for automatic handoff, unique temp path; Windows release attestation |
 | Dependency compromise | Hash-locked release environment, Dependabot, pip-audit, CodeQL, dependency review |
-| Attaching to an unrelated local DevTools service | Random reserved port, strict target URL and ID, listener ownership checks |
+| Attaching to an unrelated local DevTools service | Random reserved port, strict target URL and ID, listener ownership checks; on macOS, official bundle identity and executable-path checks plus fail-closed rediscovery |
 | Local website calling the Amazify bridge | Random bearer token, exact origin allowlist, bounded request body |
-| Token exposure in config, logs, or reports | Credential Manager migration, DPAPI fallback, redaction audit, clear-token action |
+| Token exposure in config, logs, or reports | Credential Manager/DPAPI on Windows, Keychain on macOS, secret omission and redaction |
+| Untrusted local process sending macOS instance commands | Owner-only directory and socket, UID/type checks, command allowlist |
 | Stale or conflicting runtime state | Locked snapshots, typed models, controller ownership, supervised task shutdown |
 | Silent optional network traffic | Per-provider controls, documented endpoints, redacted Diagnostics history |
 
 ## Residual Risks
 
-- A process running as the same Windows user may read app memory or use that user’s Credential Manager entries.
-- Enhanced metadata intentionally enables a local debugging interface while Amazon Music is running.
+- A process running as the same desktop user may read app memory or invoke that
+  user's credential facilities. Operating-system secret storage is not a
+  defense against already-compromised same-user code.
+- Enhanced metadata intentionally enables a local debugging interface while
+  Amazon Music is running. The CEF endpoint has no Amazon Music RPC
+  authentication; another process running as the same local user may discover
+  and connect to it even though remote-network access is blocked by loopback.
+  Closing Amazon Music or explicitly relaunching it normally removes the
+  endpoint.
 - Unsigned installers can trigger SmartScreen and do not provide publisher identity; users must verify the release checksum and GitHub provenance attestation.
+- Ad-hoc-signed macOS beta DMGs are not notarized public releases and can be
+  blocked by Gatekeeper after download. A public build requires Developer ID
+  signing, notarization, and clean-machine verification.
 - Third-party metadata layouts and APIs can change without notice and may reduce metadata quality.
 - Discord ultimately controls whether Rich Presence buttons and assets are displayed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.pytest.ini_options]
-testpaths = ["Windows/tests", "MacOS/tests"]
+testpaths = ["Windows/tests", "MacOS/tests", "Shared/tests"]
+addopts = ["--import-mode=importlib"]
 
 [tool.coverage.run]
 source = ["Windows"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.pytest.ini_options]
-testpaths = ["Windows/tests"]
+testpaths = ["Windows/tests", "MacOS/tests"]
 
 [tool.coverage.run]
 source = ["Windows"]


### PR DESCRIPTION
## Summary

- add the native macOS menu-bar beta and shared playback components
- keep macOS explicitly unreleased while Windows remains the only release artifact
- merge current dependency and security updates from master, including cryptography 50.0.0
- add platform-aware pytest collection and a native macOS CI job

## Verification

- Windows and shared suites: 88 passed
- Windows core coverage: 48.29% (45% required)
- built-in Windows self-tests: 46/46 passed
- macOS tests run in the new macOS GitHub Actions job

## Release scope

This PR does not publish or package a macOS release. Version 5.0.1 remains Windows-only.