### PR TITLE
Fix Amazon Music startup deadlock (#35)

### DIFF
--- a/Windows/AmazonMusicRPC.spec
+++ b/Windows/AmazonMusicRPC.spec
@@ -1,15 +1,21 @@
 import os
+import PySide6
 from PyInstaller.utils.hooks import collect_submodules
 
 block_cipher = None
 project_dir = os.path.dirname(os.path.abspath(SPEC))
 repository_dir = os.path.dirname(project_dir)
 shared_hidden_imports = collect_submodules('Shared')
+pyside_dir = os.path.dirname(PySide6.__file__)
+qt_runtime_binaries = [
+    (os.path.join(pyside_dir, name), '.')
+    for name in ('VCRUNTIME140.dll', 'VCRUNTIME140_1.dll')
+]
 
 a = Analysis(
     [os.path.join(project_dir, 'main.py')],
     pathex=[repository_dir, project_dir],
-    binaries=[],
+    binaries=qt_runtime_binaries,
     datas=[
         (os.path.join(project_dir, 'icon.png'), '.'),
     ],
@@ -103,6 +109,14 @@ a = Analysis(
     cipher=block_cipher,
     noarchive=False,
 )
+a.binaries = [
+    binary
+    for binary in a.binaries
+    if not (
+        os.path.basename(binary[0]).lower() == 'icuuc.dll'
+        or os.path.basename(binary[0]).lower().startswith('icudt')
+    )
+]
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 
 exe = EXE(

--- a/Windows/amazon_devtools.py
+++ b/Windows/amazon_devtools.py
@@ -1,6 +1,7 @@
 # MIT License - Copyright (c) 2026 eripum9
 
 import base64
+import ctypes
 import hashlib
 import json
 import os
@@ -11,6 +12,8 @@ import struct
 import subprocess
 import sys
 import time
+import uuid
+from ctypes import wintypes
 from urllib.parse import quote, urlparse, urlunparse
 import requests
 from config import load_config, normalize_amazon_music_link_region
@@ -26,7 +29,11 @@ DEVTOOLS_PORT_MAX = 60999
 AMAZON_PACKAGE_NAME = "AmazonMobileLLC.AmazonMusic"
 AMAZON_PACKAGE_PUBLISHER_ID = "kc6t79cpj4tp0"
 AMAZON_EXECUTABLE_NAMES = frozenset({"amazon music.exe", "amazonmusic.exe"})
+AMAZON_HELPER_EXECUTABLE_NAMES = frozenset({"amazon music helper.exe", "amazonmusichelper.exe"})
 LAUNCH_FAILURE_HELP = "Could not launch Amazon Music with enhanced metadata. Open Diagnostics and check the Amazon Music launcher entry, or paste the launcher ID from Get-StartApps."
+LAUNCH_READY_TIMEOUT_SECONDS = 45
+PROCESS_STOP_TIMEOUT_SECONDS = 8
+HELPER_SETTLE_SECONDS = 3
 SHORTCUT_NAME = "Amazon Music Metadata.lnk"
 OLD_SHORTCUT_NAMES = ("Amazon Music Beta Metadata.lnk",)
 SHORTCUT_DIR_NAME = "Amazon Music RPC"
@@ -35,6 +42,10 @@ _EXPLICIT_RE = re.compile(r"\s*\[Explicit\]\s*$", re.IGNORECASE)
 _TIME_RE = re.compile(r"^-?\d{1,2}:\d{2}(?::\d{2})?$")
 _ASIN_RE = re.compile(r"^[A-Z0-9]{10}$", re.IGNORECASE)
 _DEVTOOLS_PAGE_PATH_RE = re.compile(r"^/devtools/page/([A-Za-z0-9._:-]+)$")
+_STORE_PACKAGE_FULL_NAME_RE = re.compile(
+    rf"^{re.escape(AMAZON_PACKAGE_NAME)}_\d+(?:\.\d+){{3}}_(?:x86|x64|arm|arm64|neutral)_[A-Za-z0-9]*_{re.escape(AMAZON_PACKAGE_PUBLISHER_ID)}$",
+    re.IGNORECASE,
+)
 _DEVTOOLS_PORT = None
 _LAST_LAUNCH = {}
 _PORT_OWNER_CACHE = {"port": 0, "expires": 0.0, "value": None}
@@ -180,6 +191,309 @@ def _powershell_json(script, timeout=8):
         return []
 
 
+def _amazon_process_entries():
+    script = rf"""
+$storePattern = '\WindowsApps\{AMAZON_PACKAGE_NAME}_*__{AMAZON_PACKAGE_PUBLISHER_ID}\'
+$desktopRoot = Join-Path $env:LOCALAPPDATA 'Amazon Music'
+$items = @()
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | ForEach-Object {{
+    $path = [string]$_.ExecutablePath
+    $name = [string]$_.Name
+    $parent = if ($path) {{ Split-Path -Parent $path }} else {{ '' }}
+    $storeMatch = $path -and $path -like "*$storePattern*"
+    $desktopMatch = $path -and $parent -and $parent.Equals($desktopRoot, [System.StringComparison]::OrdinalIgnoreCase)
+    $mainMatch = $name -ieq 'Amazon Music.exe' -or $name -ieq 'AmazonMusic.exe'
+    $helperMatch = $name -ieq 'Amazon Music Helper.exe' -or $name -ieq 'AmazonMusicHelper.exe'
+    if (($storeMatch -or $desktopMatch) -and ($mainMatch -or $helperMatch)) {{
+        $items += [PSCustomObject]@{{
+            Pid = [int]$_.ProcessId
+            ParentPid = [int]$_.ParentProcessId
+            Name = $name
+            Path = $path
+            Kind = if ($helperMatch) {{ 'helper' }} else {{ 'main' }}
+        }}
+    }}
+}}
+$items | ConvertTo-Json -Compress
+"""
+    return _powershell_json(script, timeout=8)
+
+
+def _process_id(entry):
+    try:
+        value = int(entry.get("Pid") or entry.get("ProcessId"))
+    except (AttributeError, TypeError, ValueError):
+        return 0
+    return value if value > 0 else 0
+
+
+def _is_helper_process(entry):
+    kind = _clean(entry.get("Kind")).lower() if isinstance(entry, dict) else ""
+    name = _clean(entry.get("Name")).lower() if isinstance(entry, dict) else ""
+    return kind == "helper" or name in AMAZON_HELPER_EXECUTABLE_NAMES
+
+
+def _is_main_process(entry):
+    return bool(_process_id(entry)) and not _is_helper_process(entry)
+
+
+def _store_package_full_names(entries):
+    names = []
+    seen = set()
+    for entry in entries or []:
+        path = _clean(entry.get("Path")) if isinstance(entry, dict) else ""
+        for part in re.split(r"[\\/]", path):
+            if not _STORE_PACKAGE_FULL_NAME_RE.fullmatch(part):
+                continue
+            key = part.lower()
+            if key not in seen:
+                names.append(part)
+                seen.add(key)
+            break
+    return names
+
+
+def _terminate_amazon_processes(entries, force=False):
+    ids = sorted({_process_id(entry) for entry in entries if _process_id(entry)})
+    if not ids:
+        return {"ok": True, "stopped": [], "errors": []}
+    id_list = ",".join(str(pid) for pid in ids)
+    force_text = "$true" if force else "$false"
+    script = rf"""
+$ids = @({id_list})
+$force = {force_text}
+$storePattern = '\WindowsApps\{AMAZON_PACKAGE_NAME}_*__{AMAZON_PACKAGE_PUBLISHER_ID}\'
+$desktopRoot = Join-Path $env:LOCALAPPDATA 'Amazon Music'
+$results = @()
+foreach ($id in $ids) {{
+    try {{
+        $item = Get-CimInstance Win32_Process -Filter "ProcessId=$id" -ErrorAction Stop
+        $path = [string]$item.ExecutablePath
+        $name = [string]$item.Name
+        $parent = if ($path) {{ Split-Path -Parent $path }} else {{ '' }}
+        $storeMatch = $path -and $path -like "*$storePattern*"
+        $desktopMatch = $path -and $parent -and $parent.Equals($desktopRoot, [System.StringComparison]::OrdinalIgnoreCase)
+        $nameMatch = $name -ieq 'Amazon Music.exe' -or $name -ieq 'AmazonMusic.exe' -or $name -ieq 'Amazon Music Helper.exe' -or $name -ieq 'AmazonMusicHelper.exe'
+        if (-not (($storeMatch -or $desktopMatch) -and $nameMatch)) {{
+            $results += [PSCustomObject]@{{ Pid = $id; Stopped = $false; Error = 'Process identity changed' }}
+            continue
+        }}
+        $process = Get-Process -Id $id -ErrorAction Stop
+        if ($force) {{
+            Stop-Process -Id $id -Force -ErrorAction Stop
+            $results += [PSCustomObject]@{{ Pid = $id; Stopped = $true; Error = '' }}
+        }} else {{
+            $closed = $process.CloseMainWindow()
+            $results += [PSCustomObject]@{{ Pid = $id; Stopped = [bool]$closed; Error = '' }}
+        }}
+    }} catch {{
+        $results += [PSCustomObject]@{{ Pid = $id; Stopped = $false; Error = [string]$_.Exception.Message }}
+    }}
+}}
+$results | ConvertTo-Json -Compress
+"""
+    rows = _powershell_json(script, timeout=10)
+    stopped = [str(_process_id(row)) for row in rows if row.get("Stopped") and _process_id(row)]
+    errors = [_clean(row.get("Error")) for row in rows if row.get("Error")]
+    return {"ok": not errors, "stopped": stopped, "errors": errors}
+
+
+def stop_amazon_music(
+    timeout=PROCESS_STOP_TIMEOUT_SECONDS,
+    poll_interval=0.35,
+    process_entries_fn=None,
+    terminate_fn=None,
+    sleep_fn=None,
+):
+    entries_fn = process_entries_fn or _amazon_process_entries
+    stop_fn = terminate_fn or _terminate_amazon_processes
+    sleeper = sleep_fn or time.sleep
+    initial = entries_fn()
+    if not initial:
+        return {"ok": True, "stopped": [], "remaining": [], "errors": []}
+    seen = {_process_id(entry) for entry in initial if _process_id(entry)}
+    errors = []
+    graceful = stop_fn(initial, False)
+    errors.extend(graceful.get("errors", []))
+    sleeper(min(1.2, max(0.0, timeout)))
+    attempts = max(2, int(max(0.1, timeout) / max(0.05, poll_interval)))
+    empty_polls = 0
+    remaining = initial
+    for _ in range(attempts):
+        remaining = entries_fn()
+        if not remaining:
+            empty_polls += 1
+            if empty_polls >= 2:
+                return {
+                    "ok": True,
+                    "stopped": [str(pid) for pid in sorted(seen)],
+                    "remaining": [],
+                    "errors": errors,
+                }
+        else:
+            empty_polls = 0
+            seen.update(_process_id(entry) for entry in remaining if _process_id(entry))
+            forced = stop_fn(remaining, True)
+            errors.extend(forced.get("errors", []))
+        sleeper(poll_interval)
+    remaining = entries_fn()
+    remaining_ids = [str(_process_id(entry)) for entry in remaining if _process_id(entry)]
+    return {
+        "ok": not remaining_ids,
+        "stopped": [str(pid) for pid in sorted(seen) if str(pid) not in remaining_ids],
+        "remaining": remaining_ids,
+        "errors": errors,
+        "error": "Amazon Music processes did not exit" if remaining_ids else "",
+    }
+
+
+def stop_amazon_music_for_restart(
+    timeout=15,
+    poll_interval=0.5,
+    process_entries_fn=None,
+    terminate_fn=None,
+    sleep_fn=None,
+):
+    entries_fn = process_entries_fn or _amazon_process_entries
+    stop_fn = terminate_fn or _terminate_amazon_processes
+    sleeper = sleep_fn or time.sleep
+    initial = entries_fn()
+    mains = [entry for entry in initial if _is_main_process(entry)]
+    helpers = [entry for entry in initial if _is_helper_process(entry)]
+    helper_ids = [str(_process_id(entry)) for entry in helpers if _process_id(entry)]
+    if not mains:
+        return {
+            "ok": True,
+            "stopped": [],
+            "remaining": [],
+            "preserved_helpers": helper_ids,
+            "errors": [],
+        }
+    main_ids = {_process_id(entry) for entry in mains if _process_id(entry)}
+    roots = [
+        entry
+        for entry in mains
+        if int(entry.get("ParentPid") or 0) not in main_ids
+    ] or mains
+    graceful = stop_fn(roots, False)
+    errors = list(graceful.get("errors", []))
+    attempts = max(2, int(max(0.1, timeout) / max(0.05, poll_interval)))
+    empty_polls = 0
+    for _ in range(attempts):
+        remaining = [entry for entry in entries_fn() if _is_main_process(entry)]
+        if not remaining:
+            empty_polls += 1
+            if empty_polls >= 2:
+                return {
+                    "ok": True,
+                    "stopped": [str(pid) for pid in sorted(main_ids)],
+                    "remaining": [],
+                    "preserved_helpers": helper_ids,
+                    "errors": errors,
+                }
+        else:
+            empty_polls = 0
+        sleeper(poll_interval)
+    remaining = [entry for entry in entries_fn() if _is_main_process(entry)]
+    remaining_ids = [str(_process_id(entry)) for entry in remaining if _process_id(entry)]
+    return {
+        "ok": False,
+        "stopped": [str(pid) for pid in sorted(main_ids) if str(pid) not in remaining_ids],
+        "remaining": remaining_ids,
+        "preserved_helpers": helper_ids,
+        "errors": errors,
+        "error": "Amazon Music did not close cleanly. Close it normally, then try enhanced metadata again.",
+    }
+
+
+def stop_amazon_helpers(
+    timeout=6,
+    poll_interval=0.35,
+    process_entries_fn=None,
+    terminate_fn=None,
+    sleep_fn=None,
+):
+    entries_fn = process_entries_fn or _amazon_process_entries
+    stop_fn = terminate_fn or _terminate_amazon_processes
+    sleeper = sleep_fn or time.sleep
+    initial = [entry for entry in entries_fn() if _is_helper_process(entry)]
+    if not initial:
+        return {"ok": True, "stopped": [], "remaining": [], "errors": []}
+    seen = {_process_id(entry) for entry in initial if _process_id(entry)}
+    forced = stop_fn(initial, True)
+    errors = list(forced.get("errors", []))
+    attempts = max(2, int(max(0.1, timeout) / max(0.05, poll_interval)))
+    empty_polls = 0
+    for _ in range(attempts):
+        remaining = [entry for entry in entries_fn() if _is_helper_process(entry)]
+        if not remaining:
+            empty_polls += 1
+            if empty_polls >= 2:
+                return {
+                    "ok": True,
+                    "stopped": [str(pid) for pid in sorted(seen)],
+                    "remaining": [],
+                    "errors": errors,
+                }
+        else:
+            empty_polls = 0
+            seen.update(_process_id(entry) for entry in remaining if _process_id(entry))
+            retried = stop_fn(remaining, True)
+            errors.extend(retried.get("errors", []))
+        sleeper(poll_interval)
+    remaining = [entry for entry in entries_fn() if _is_helper_process(entry)]
+    remaining_ids = [str(_process_id(entry)) for entry in remaining if _process_id(entry)]
+    return {
+        "ok": not remaining_ids,
+        "stopped": [str(pid) for pid in sorted(seen) if str(pid) not in remaining_ids],
+        "remaining": remaining_ids,
+        "errors": errors,
+        "error": "Amazon Music Helper did not exit" if remaining_ids else "",
+    }
+
+
+def _prepare_amazon_launch(process_entries_fn=None, helper_stop_fn=None, package_stop_fn=None, sleep_fn=None):
+    entries_fn = process_entries_fn or _amazon_process_entries
+    sleeper = sleep_fn or time.sleep
+    entries = entries_fn()
+    mains = [entry for entry in entries if _is_main_process(entry)]
+    if mains:
+        return {
+            "ok": False,
+            "error": "Amazon Music is already running without enhanced metadata. Close it or use metadata restart repair before launching it again.",
+            "main_processes": [str(_process_id(entry)) for entry in mains],
+        }
+    helpers = [entry for entry in entries if _is_helper_process(entry)]
+    helper_ids = [str(_process_id(entry)) for entry in helpers if _process_id(entry)]
+    if not helpers:
+        return {"ok": True, "stale_helpers": [], "retired_helpers": []}
+    package_names = _store_package_full_names(helpers)
+    if package_names and package_stop_fn is None:
+        cleanup = stop_amazon_store_packages(package_names, process_entries_fn=entries_fn)
+    elif package_names:
+        cleanup = package_stop_fn(package_names)
+    elif helper_stop_fn is None:
+        cleanup = stop_amazon_helpers(process_entries_fn=entries_fn)
+    else:
+        cleanup = helper_stop_fn()
+    if not cleanup.get("ok"):
+        return {
+            "ok": False,
+            "error": "Amazon Music Helper could not be prepared for enhanced metadata. End it in Task Manager and try again.",
+            "stale_helpers": helper_ids,
+            "retired_helpers": cleanup.get("stopped", []),
+            "cleanup": cleanup,
+        }
+    sleeper(HELPER_SETTLE_SECONDS)
+    return {
+        "ok": True,
+        "stale_helpers": helper_ids,
+        "retired_helpers": cleanup.get("stopped", helper_ids),
+        "reset_packages": cleanup.get("packages", []),
+        "cleanup": cleanup,
+    }
+
+
 def _looks_like_path(value):
     text = _clean(value)
     return bool(
@@ -191,6 +505,14 @@ def _looks_like_path(value):
             or "/" in text
         )
     )
+
+
+def _looks_like_aumid(value):
+    text = _clean(value)
+    if _looks_like_path(text) or text.count("!") != 1:
+        return False
+    family, app_id = text.split("!", 1)
+    return bool(family.strip() and app_id.strip())
 
 
 def _is_local_absolute_path(value):
@@ -238,6 +560,8 @@ def validate_launcher_override(value, exists_fn=os.path.exists):
         return ""
     if _looks_like_path(text) and not _is_allowed_amazon_exe(text, exists_fn):
         raise ValueError("Executable launcher overrides must point to an existing local Amazon Music .exe.")
+    if not _looks_like_path(text) and not _looks_like_aumid(text):
+        raise ValueError("Launcher IDs must use the PackageFamily!Application format shown by Get-StartApps.")
     return text
 
 
@@ -254,7 +578,7 @@ def _launcher_candidate_from_value(value, aumid_method, exe_method, source, exis
         return None
     if _looks_like_path(text):
         return _launcher_candidate("exe", text, exe_method, source) if _is_allowed_amazon_exe(text, exists_fn) else None
-    return _launcher_candidate("aumid", text, aumid_method, source)
+    return _launcher_candidate("aumid", text, aumid_method, source) if _looks_like_aumid(text) else None
 
 
 def _build_aumid(package_family, app_id):
@@ -366,6 +690,203 @@ def _wait_for_page_target(port, timeout=9):
     return False
 
 
+class _GUID(ctypes.Structure):
+    _fields_ = [
+        ("Data1", wintypes.DWORD),
+        ("Data2", wintypes.WORD),
+        ("Data3", wintypes.WORD),
+        ("Data4", ctypes.c_ubyte * 8),
+    ]
+
+    @classmethod
+    def from_string(cls, value):
+        return cls.from_buffer_copy(uuid.UUID(value).bytes_le)
+
+
+def _activate_aumid_native(app_id, args):
+    if os.name != "nt":
+        raise OSError("Native application activation is only available on Windows")
+    ole32 = ctypes.windll.ole32
+    ole32.CoInitializeEx.argtypes = [ctypes.c_void_p, wintypes.DWORD]
+    ole32.CoInitializeEx.restype = ctypes.c_long
+    ole32.CoCreateInstance.argtypes = [
+        ctypes.POINTER(_GUID),
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.POINTER(_GUID),
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    ole32.CoCreateInstance.restype = ctypes.c_long
+    ole32.CoUninitialize.argtypes = []
+    ole32.CoUninitialize.restype = None
+    clsid = _GUID.from_string("45BA127D-10A8-46EA-8AB7-56EA9078943C")
+    iid = _GUID.from_string("2E941141-7F97-4756-BA1D-9DECDE894A3D")
+    instance = ctypes.c_void_p()
+    coinit_hr = ole32.CoInitializeEx(None, 0x2)
+    should_uninitialize = coinit_hr >= 0
+    if coinit_hr < 0 and coinit_hr != -2147417850:
+        raise OSError(f"CoInitializeEx failed: 0x{coinit_hr & 0xFFFFFFFF:08X}")
+    try:
+        hr = ole32.CoCreateInstance(
+            ctypes.byref(clsid),
+            None,
+            0x1,
+            ctypes.byref(iid),
+            ctypes.byref(instance),
+        )
+        if hr < 0 or not instance.value:
+            raise OSError(f"CoCreateInstance failed: 0x{hr & 0xFFFFFFFF:08X}")
+        interface = ctypes.cast(instance, ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)))
+        activate = ctypes.WINFUNCTYPE(
+            ctypes.c_long,
+            ctypes.c_void_p,
+            wintypes.LPCWSTR,
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+        )(interface.contents[3])
+        process_id = wintypes.DWORD()
+        hr = activate(instance, app_id, args, 0, ctypes.byref(process_id))
+        if hr < 0:
+            raise OSError(f"ActivateApplication failed: 0x{hr & 0xFFFFFFFF:08X}")
+        return int(process_id.value)
+    finally:
+        if instance.value:
+            interface = ctypes.cast(instance, ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)))
+            release = ctypes.WINFUNCTYPE(wintypes.ULONG, ctypes.c_void_p)(interface.contents[2])
+            release(instance)
+        if should_uninitialize:
+            ole32.CoUninitialize()
+
+
+def _terminate_store_package_native(package_full_name):
+    if os.name != "nt":
+        raise OSError("Package lifecycle control is only available on Windows")
+    if not _STORE_PACKAGE_FULL_NAME_RE.fullmatch(_clean(package_full_name)):
+        raise ValueError("Amazon Music package identity was invalid")
+    ole32 = ctypes.windll.ole32
+    ole32.CoInitializeEx.argtypes = [ctypes.c_void_p, wintypes.DWORD]
+    ole32.CoInitializeEx.restype = ctypes.c_long
+    ole32.CoCreateInstance.argtypes = [
+        ctypes.POINTER(_GUID),
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.POINTER(_GUID),
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    ole32.CoCreateInstance.restype = ctypes.c_long
+    ole32.CoUninitialize.argtypes = []
+    ole32.CoUninitialize.restype = None
+    clsid = _GUID.from_string("B1AEC16F-2383-4852-B0E9-8F0B1DC66B4D")
+    iid = _GUID.from_string("F27C3930-8029-4AD1-94E3-3DBA417810C1")
+    instance = ctypes.c_void_p()
+    coinit_hr = ole32.CoInitializeEx(None, 0x2)
+    should_uninitialize = coinit_hr >= 0
+    if coinit_hr < 0 and coinit_hr != -2147417850:
+        raise OSError(f"CoInitializeEx failed: 0x{coinit_hr & 0xFFFFFFFF:08X}")
+    try:
+        hr = ole32.CoCreateInstance(
+            ctypes.byref(clsid),
+            None,
+            0x1,
+            ctypes.byref(iid),
+            ctypes.byref(instance),
+        )
+        if hr < 0 or not instance.value:
+            raise OSError(f"CoCreateInstance failed: 0x{hr & 0xFFFFFFFF:08X}")
+        interface = ctypes.cast(instance, ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)))
+        terminate = ctypes.WINFUNCTYPE(
+            ctypes.c_long,
+            ctypes.c_void_p,
+            wintypes.LPCWSTR,
+        )(interface.contents[7])
+        hr = terminate(instance, package_full_name)
+        if hr < 0:
+            raise OSError(f"TerminateAllProcesses failed: 0x{hr & 0xFFFFFFFF:08X}")
+    finally:
+        if instance.value:
+            interface = ctypes.cast(instance, ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)))
+            release = ctypes.WINFUNCTYPE(wintypes.ULONG, ctypes.c_void_p)(interface.contents[2])
+            release(instance)
+        if should_uninitialize:
+            ole32.CoUninitialize()
+
+
+def stop_amazon_store_packages(
+    package_full_names,
+    timeout=8,
+    poll_interval=0.35,
+    process_entries_fn=None,
+    terminate_package_fn=None,
+    sleep_fn=None,
+):
+    entries_fn = process_entries_fn or _amazon_process_entries
+    terminate_fn = terminate_package_fn or _terminate_store_package_native
+    sleeper = sleep_fn or time.sleep
+    packages = []
+    seen_packages = set()
+    for value in package_full_names or []:
+        name = _clean(value)
+        key = name.lower()
+        if _STORE_PACKAGE_FULL_NAME_RE.fullmatch(name) and key not in seen_packages:
+            packages.append(name)
+            seen_packages.add(key)
+    if not packages:
+        return {
+            "ok": False,
+            "stopped": [],
+            "remaining": [],
+            "packages": [],
+            "errors": ["Amazon Music package identity was unavailable"],
+            "error": "Amazon Music package identity was unavailable",
+        }
+    initial = entries_fn()
+    seen = {_process_id(entry) for entry in initial if _process_id(entry)}
+    errors = []
+    for package in packages:
+        try:
+            terminate_fn(package)
+        except Exception as error:
+            errors.append(_clean(error))
+    if errors:
+        return {
+            "ok": False,
+            "stopped": [],
+            "remaining": [str(pid) for pid in sorted(seen)],
+            "packages": packages,
+            "errors": errors,
+            "error": "Windows could not reset the Amazon Music package lifecycle",
+        }
+    attempts = max(2, int(max(0.1, timeout) / max(0.05, poll_interval)))
+    empty_polls = 0
+    remaining = initial
+    for _ in range(attempts):
+        remaining = entries_fn()
+        if not remaining:
+            empty_polls += 1
+            if empty_polls >= 2:
+                return {
+                    "ok": True,
+                    "stopped": [str(pid) for pid in sorted(seen)],
+                    "remaining": [],
+                    "packages": packages,
+                    "errors": [],
+                }
+        else:
+            empty_polls = 0
+            seen.update(_process_id(entry) for entry in remaining if _process_id(entry))
+        sleeper(poll_interval)
+    remaining_ids = [str(_process_id(entry)) for entry in remaining if _process_id(entry)]
+    return {
+        "ok": False,
+        "stopped": [str(pid) for pid in sorted(seen) if str(pid) not in remaining_ids],
+        "remaining": remaining_ids,
+        "packages": packages,
+        "errors": [],
+        "error": "Amazon Music package processes did not exit",
+    }
+
+
 def _launch_aumid(app_id, port):
     args = f"--remote-debugging-port={port}"
     script = f"""
@@ -406,12 +927,30 @@ Add-Type -TypeDefinition $code
 [AppActivator]::Activate({_ps_literal(app_id)}, {_ps_literal(args)})
 """
     try:
+        pid = _activate_aumid_native(app_id, args)
+        return {"ok": True, "pid": str(pid), "activation": "native"}
+    except Exception as error:
+        native_error = _clean(error)
+    try:
         completed = _run_powershell(script, 15)
-    except Exception as e:
-        return {"ok": False, "error": str(e)}
+    except Exception as error:
+        return {
+            "ok": False,
+            "error": f"Native activation failed: {native_error}; PowerShell activation failed: {_clean(error)}",
+        }
     if completed.returncode != 0:
-        return {"ok": False, "error": _clean(completed.stderr) or "Could not launch Amazon Music"}
-    return {"ok": True, "pid": _clean(completed.stdout)}
+        powershell_error = _clean(completed.stderr) or "Could not launch Amazon Music"
+        return {
+            "ok": False,
+            "error": f"Native activation failed: {native_error}; PowerShell activation failed: {powershell_error}",
+        }
+    pid = ""
+    for line in reversed(completed.stdout.splitlines()):
+        value = _clean(line)
+        if value.isdigit() and int(value) > 0:
+            pid = value
+            break
+    return {"ok": True, "pid": pid, "activation": "powershell-fallback"}
 
 
 def _launch_exe(path, port):
@@ -830,6 +1369,83 @@ class _CdpSocket:
                 return message
 
 
+_BOOT_STATE_EXPRESSION = r"""
+(() => {
+  const transport = document.querySelector('#transportContainer.hasTrackLoaded') || document.querySelector('#transportContainer') || document.querySelector('#transport');
+  const splash = document.querySelector('.splashScreen');
+  let splashVisible = false;
+  if (splash) {
+    const style = getComputedStyle(splash);
+    const rect = splash.getBoundingClientRect();
+    const opacity = Number.parseFloat(style.opacity || '1');
+    splashVisible = style.display !== 'none' && style.visibility !== 'hidden' && (!Number.isFinite(opacity) || opacity > 0) && rect.width > 0 && rect.height > 0;
+  }
+  return {
+    readyState: document.readyState,
+    transport: Boolean(transport),
+    splashVisible,
+    bodyChildren: document.body ? document.body.children.length : 0
+  };
+})()
+"""
+
+
+def _page_boot_state(port):
+    target = _page_target(port=port)
+    if not target:
+        return {"ready": False, "status": "target-missing", "detail": "Enhanced metadata page was not available"}
+    client = None
+    try:
+        client = _CdpSocket(
+            target["webSocketDebuggerUrl"],
+            expected_port=port,
+            expected_target_id=target.get("id", ""),
+        )
+        response = client.request(
+            "Runtime.evaluate",
+            {"expression": _BOOT_STATE_EXPRESSION, "returnByValue": True},
+        )
+        value = response.get("result", {}).get("result", {}).get("value")
+        if not isinstance(value, dict):
+            return {"ready": False, "status": "unknown", "detail": "Amazon Music startup state was unavailable"}
+        transport = bool(value.get("transport"))
+        splash_visible = bool(value.get("splashVisible"))
+        document_ready = value.get("readyState") == "complete"
+        body_ready = int(value.get("bodyChildren") or 0) > 0
+        ready = transport or (document_ready and body_ready and not splash_visible)
+        return {
+            "ready": ready,
+            "status": "ready" if ready else "loading",
+            "detail": "Amazon Music interface is ready" if ready else "Amazon Music remained on its loading screen",
+            "transport": transport,
+            "splash_visible": splash_visible,
+        }
+    except Exception as error:
+        return {"ready": False, "status": "error", "detail": _clean(error)}
+    finally:
+        if client:
+            client.close()
+
+
+def _wait_for_app_ready(
+    port,
+    timeout=LAUNCH_READY_TIMEOUT_SECONDS,
+    poll_interval=0.5,
+    boot_state_fn=None,
+    sleep_fn=None,
+):
+    state_fn = boot_state_fn or _page_boot_state
+    sleeper = sleep_fn or time.sleep
+    attempts = max(1, int(max(0.1, timeout) / max(0.05, poll_interval)))
+    state = {"ready": False, "status": "loading", "detail": "Amazon Music is loading"}
+    for _ in range(attempts):
+        state = state_fn(port)
+        if state.get("ready"):
+            return {"ok": True, **state}
+        sleeper(poll_interval)
+    return {"ok": False, **state, "detail": "Amazon Music remained on its loading screen"}
+
+
 _TRANSPORT_EXPRESSION = r"""
 (async () => {
   const clean = (value) => String(value || '').replace(/\s+/g, ' ').trim();
@@ -1055,8 +1671,25 @@ def launch_amazon_music_devtools(launcher_override=None):
             owner = _devtools_owner_trust(port, force=True)
             if not owner.get("trusted"):
                 return {"ok": False, "error": owner.get("detail"), "port": port, "owner": owner}
+            readiness = _wait_for_app_ready(port, timeout=8)
+            if not readiness.get("ok"):
+                return {
+                    "ok": False,
+                    "error": readiness.get("detail"),
+                    "port": port,
+                    "owner": owner,
+                    "readiness": readiness,
+                }
             _remember_launch("existing", "", port, owner=owner)
-            return {"ok": True, "pid": "", "port": port, "already_running": True, "method": "existing", "owner": owner}
+            return {
+                "ok": True,
+                "pid": "",
+                "port": port,
+                "already_running": True,
+                "method": "existing",
+                "owner": owner,
+                "readiness": readiness,
+            }
         if _valid_devtools_port(os.environ.get(DEVTOOLS_PORT_ENV)) == port:
             return {"ok": False, "error": f"Shared metadata port {port} is already in use", "port": port}
         for _ in range(8):
@@ -1066,6 +1699,9 @@ def launch_amazon_music_devtools(launcher_override=None):
                 break
         else:
             return {"ok": False, "error": "Could not find a free local metadata port"}
+    preparation = _prepare_amazon_launch()
+    if not preparation.get("ok"):
+        return {"ok": False, "error": preparation.get("error"), "port": port, "preparation": preparation}
     try:
         port, reservation = _reserve_devtools_port(port)
     except RuntimeError:
@@ -1092,7 +1728,27 @@ def launch_amazon_music_devtools(launcher_override=None):
                 )
                 if not owner.get("trusted"):
                     attempts.append(f"{_candidate_label(candidate)}: {owner.get('detail')}")
-                    continue
+                    cleanup = stop_amazon_music(timeout=6)
+                    return {
+                        "ok": False,
+                        "error": _format_launcher_failure(attempts),
+                        "port": port,
+                        "attempts": attempts,
+                        "cleanup": cleanup,
+                    }
+                readiness = _wait_for_app_ready(port)
+                if not readiness.get("ok"):
+                    attempts.append(f"{_candidate_label(candidate)}: Amazon Music remained on its loading screen")
+                    cleanup = stop_amazon_music(timeout=6)
+                    _clear_cache()
+                    return {
+                        "ok": False,
+                        "error": _format_launcher_failure(attempts),
+                        "port": port,
+                        "attempts": attempts,
+                        "cleanup": cleanup,
+                        "readiness": readiness,
+                    }
                 _remember_launch(candidate.get("method", ""), candidate.get("value", ""), port, result.get("pid", ""), owner)
                 return {
                     "ok": True,
@@ -1101,8 +1757,20 @@ def launch_amazon_music_devtools(launcher_override=None):
                     "method": candidate.get("method", ""),
                     "launcher": candidate.get("value", ""),
                     "owner": owner,
+                    "activation": result.get("activation", ""),
+                    "preparation": preparation,
+                    "readiness": readiness,
                 }
             attempts.append(f"{_candidate_label(candidate)}: metadata target did not appear")
+            cleanup = stop_amazon_music(timeout=6)
+            if not cleanup.get("ok"):
+                return {
+                    "ok": False,
+                    "error": f"{_format_launcher_failure(attempts)} Failed launch cleanup did not finish.",
+                    "port": port,
+                    "attempts": attempts,
+                    "cleanup": cleanup,
+                }
         else:
             attempts.append(_attempt_failure(candidate, result.get("error", "")))
     return {"ok": False, "error": _format_launcher_failure(attempts), "port": port, "attempts": attempts}
@@ -1129,50 +1797,26 @@ if ($targets.Count -gt 0) {{ "true" }} else {{ "false" }}
     return completed.returncode == 0 and _clean(completed.stdout).lower() == "true"
 
 
-def stop_amazon_music():
-    script = rf"""
-$package = '{AMAZON_PACKAGE_NAME}'
-$targets = @(Get-Process | Where-Object {{
-    $path = ""
-    try {{ $path = $_.Path }} catch {{ }}
-    ($path -and $path -like "*$package*") -or
-    ($_.ProcessName -eq "AmazonMusic") -or
-    ($_.ProcessName -eq "Amazon Music") -or
-    ($_.ProcessName -eq "Amazon Music Helper")
-}})
-$ids = @($targets | Select-Object -ExpandProperty Id)
-foreach ($proc in $targets) {{
-    try {{ $proc.CloseMainWindow() | Out-Null }} catch {{ }}
-}}
-Start-Sleep -Milliseconds 1200
-foreach ($id in $ids) {{
-    try {{
-        $proc = Get-Process -Id $id -ErrorAction Stop
-        if (-not $proc.HasExited) {{
-            Stop-Process -Id $id -Force -ErrorAction Stop
-        }}
-    }} catch {{ }}
-}}
-($ids -join ',')
-"""
-    try:
-        completed = _run_powershell(script, 15)
-    except Exception as e:
-        return {"ok": False, "error": str(e), "stopped": []}
-    stopped = [item for item in _clean(completed.stdout).split(",") if item]
-    if completed.returncode != 0:
-        return {"ok": False, "error": _clean(completed.stderr) or "Could not stop Amazon Music", "stopped": stopped}
-    return {"ok": True, "stopped": stopped}
-
-
 def restart_amazon_music_devtools():
-    stop_result = stop_amazon_music()
+    package_names = _store_package_full_names(_amazon_process_entries())
+    stop_result = stop_amazon_music_for_restart()
     if not stop_result.get("ok"):
         return stop_result
+    if package_names:
+        cleanup_result = stop_amazon_store_packages(package_names)
+    else:
+        cleanup_result = stop_amazon_helpers()
+    if not cleanup_result.get("ok"):
+        return cleanup_result
     _clear_cache()
-    time.sleep(1)
+    time.sleep(HELPER_SETTLE_SECONDS)
     launch_result = launch_amazon_music_devtools()
-    return {**launch_result, "stopped": stop_result.get("stopped", [])}
+    return {
+        **launch_result,
+        "stopped": stop_result.get("stopped", []),
+        "retired_helpers": cleanup_result.get("stopped", []),
+        "reset_packages": cleanup_result.get("packages", []),
+    }
 
 
 def _start_menu_shortcut_path():

--- a/Windows/amazon_status_overlay.py
+++ b/Windows/amazon_status_overlay.py
@@ -4,7 +4,7 @@ import base64
 import json
 import threading
 
-from amazon_devtools import _CdpSocket, _page_target, get_devtools_port
+from amazon_devtools import _CdpSocket, _page_boot_state, _page_target, get_devtools_port
 
 
 OVERLAY_VERSION = "2026.07.16.1"
@@ -142,13 +142,19 @@ class AmazonStatusOverlay:
                     self._close_client()
                     self._stop_event.wait(2)
                     continue
+                port = get_devtools_port(False)
+                readiness = _page_boot_state(port) if port else {"ready": False}
+                if not readiness.get("ready"):
+                    self._close_client()
+                    self._stop_event.wait(1)
+                    continue
                 target_id = target.get("id") or target.get("webSocketDebuggerUrl")
                 if not self._client or target_id != last_target:
                     self._close_client()
                     self._client = _CdpSocket(
                         target["webSocketDebuggerUrl"],
                         timeout=5,
-                        expected_port=get_devtools_port(False),
+                        expected_port=port,
                         expected_target_id=target.get("id", ""),
                     )
                     self._context_id = None

--- a/Windows/config.py
+++ b/Windows/config.py
@@ -27,7 +27,7 @@ if not os.environ.get("APPDATA") or getattr(sys, "frozen", False) is False:
     CONFIG_DIR = os.path.dirname(os.path.abspath(__file__))
     CONFIG_PATH = os.path.join(CONFIG_DIR, "config.json")
 
-APP_VERSION = "5.0.1"
+APP_VERSION = "5.0.2"
 AMAZON_MUSIC_LINK_REGIONS = (
     "com",
     "de",

--- a/Windows/installer.iss
+++ b/Windows/installer.iss
@@ -1,5 +1,5 @@
 #define MyAppName "Amazon Music RPC"
-#define MyAppVersion "5.0.1"
+#define MyAppVersion "5.0.2"
 #define MyAppPublisher "PumpgunStudios"
 #define MyAppExeName "AmazonMusicRPC.exe"
 

--- a/Windows/launcher_diagnostics.py
+++ b/Windows/launcher_diagnostics.py
@@ -30,6 +30,8 @@ def classify_launcher_error(error):
         return "unsupported_debug_flag"
     if "metadata target did not appear" in text:
         return "metadata_target_missing"
+    if "remained on its loading screen" in text:
+        return "loading_screen_stuck"
     if "python" in text and ("_mei" in text or "python314.dll" in text):
         return "stale_pyinstaller_temp"
     if "system cannot find the file specified" in text or "指定されたファイルが見つかりません" in text:
@@ -64,6 +66,8 @@ def launcher_failure_advice(attempts):
         return "Windows PowerShell could not be started, so launcher discovery cannot run."
     if "metadata_target_missing" in categories:
         return "Amazon Music opened, but the enhanced metadata page did not appear on the selected port."
+    if "loading_screen_stuck" in categories:
+        return "Amazon Music did not finish starting in metadata mode. The failed helper was closed so normal launches remain available."
     return ""
 
 

--- a/Windows/media_reader.py
+++ b/Windows/media_reader.py
@@ -66,7 +66,7 @@ async def get_current_track():
 def get_track_sync(timeout=2.5):
     try:
         return asyncio.run(asyncio.wait_for(get_current_track(), timeout))
-    except asyncio.TimeoutError:
+    except (asyncio.TimeoutError, OSError, RuntimeError):
         return None
 
 

--- a/Windows/tests/test_amazon_devtools.py
+++ b/Windows/tests/test_amazon_devtools.py
@@ -2,6 +2,7 @@
 
 import inspect
 import os
+from types import SimpleNamespace
 
 import amazon_devtools
 
@@ -82,6 +83,7 @@ def test_devtools_launcher_candidate_ordering_and_fallbacks():
     exists = lambda path: path == existing_path
     start_apps = [
         {"Name": "Amazon Music", "AppID": "Website.Package!AmazonMusic"},
+        {"Name": "Amazon Music", "AppID": "Amazon.Music"},
         {"Name": "Amazon Music", "AppID": existing_path},
         {"Name": "Amazon Music", "AppID": r"C:\Missing\Amazon Music.exe"},
         {"Name": "Amazon Music RPC", "AppID": r"C:\Amazon Music RPC\AmazonMusicRPC.exe"},
@@ -104,6 +106,7 @@ def test_devtools_launcher_candidate_ordering_and_fallbacks():
     ]
     assert candidates[-1]["method"] == "hardcoded-store"
     assert candidates[-1]["value"] == amazon_devtools.APP_USER_MODEL_ID
+    assert all(candidate["value"] != "Amazon.Music" for candidate in candidates)
     assert not amazon_devtools._start_app_candidates(
         [{"Name": "Amazon Music", "AppID": r"C:\Missing\Amazon Music.exe"}],
         lambda path: False,
@@ -113,6 +116,262 @@ def test_devtools_launcher_candidate_ordering_and_fallbacks():
         "Package was not found. 0x80073CF1",
     )
     assert "package was not found" in failure.lower()
+
+
+def test_devtools_aumid_launch_prefers_native_activation(monkeypatch):
+    monkeypatch.setattr(amazon_devtools, "_activate_aumid_native", lambda app_id, args: 4321)
+    monkeypatch.setattr(
+        amazon_devtools,
+        "_run_powershell",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("PowerShell fallback should not run")),
+    )
+    result = amazon_devtools._launch_aumid("Package.Family!AmazonMusic", 52856)
+    assert result == {"ok": True, "pid": "4321", "activation": "native"}
+
+
+def test_devtools_aumid_launch_uses_powershell_fallback(monkeypatch):
+    monkeypatch.setattr(
+        amazon_devtools,
+        "_activate_aumid_native",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("native activation failed")),
+    )
+    monkeypatch.setattr(
+        amazon_devtools,
+        "_run_powershell",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="4321\n", stderr=""),
+    )
+    result = amazon_devtools._launch_aumid("Package.Family!AmazonMusic", 52856)
+    assert result == {"ok": True, "pid": "4321", "activation": "powershell-fallback"}
+
+
+def test_devtools_stop_waits_for_respawned_helper():
+    main = {"Pid": 10, "Name": "Amazon Music.exe", "Kind": "main"}
+    helper = {"Pid": 11, "Name": "Amazon Music Helper.exe", "Kind": "helper"}
+    respawned = {"Pid": 12, "Name": "Amazon Music Helper.exe", "Kind": "helper"}
+    states = [[main, helper], [helper], [respawned], [], []]
+    calls = []
+
+    def entries():
+        return states.pop(0) if states else []
+
+    def terminate(items, force):
+        calls.append((force, [_entry["Pid"] for _entry in items]))
+        return {"ok": True, "stopped": [str(_entry["Pid"]) for _entry in items], "errors": []}
+
+    result = amazon_devtools.stop_amazon_music(
+        timeout=2,
+        poll_interval=0.1,
+        process_entries_fn=entries,
+        terminate_fn=terminate,
+        sleep_fn=lambda delay: None,
+    )
+    assert result["ok"] is True
+    assert result["remaining"] == []
+    assert (False, [10, 11]) in calls
+    assert (True, [11]) in calls
+    assert (True, [12]) in calls
+
+
+def test_devtools_restart_closes_main_processes_and_preserves_helper():
+    root = {"Pid": 20, "ParentPid": 1, "Name": "Amazon Music.exe", "Kind": "main"}
+    child = {"Pid": 21, "ParentPid": 20, "Name": "Amazon Music.exe", "Kind": "main"}
+    helper = {"Pid": 22, "ParentPid": 20, "Name": "Amazon Music Helper.exe", "Kind": "helper"}
+    states = [[root, child, helper], [root, child, helper], [helper], [helper]]
+    calls = []
+
+    def entries():
+        return states.pop(0) if states else [helper]
+
+    def terminate(items, force):
+        calls.append((force, [entry["Pid"] for entry in items]))
+        return {"ok": True, "stopped": [str(entry["Pid"]) for entry in items], "errors": []}
+
+    result = amazon_devtools.stop_amazon_music_for_restart(
+        timeout=2,
+        poll_interval=0.1,
+        process_entries_fn=entries,
+        terminate_fn=terminate,
+        sleep_fn=lambda delay: None,
+    )
+    assert result["ok"] is True
+    assert result["preserved_helpers"] == ["22"]
+    assert calls == [(False, [20])]
+
+
+def test_devtools_restart_refuses_to_force_a_running_main_process():
+    main = {"Pid": 20, "ParentPid": 1, "Name": "Amazon Music.exe", "Kind": "main"}
+    calls = []
+
+    def terminate(items, force):
+        calls.append(force)
+        return {"ok": True, "stopped": [], "errors": []}
+
+    result = amazon_devtools.stop_amazon_music_for_restart(
+        timeout=0.2,
+        poll_interval=0.1,
+        process_entries_fn=lambda: [main],
+        terminate_fn=terminate,
+        sleep_fn=lambda delay: None,
+    )
+    assert result["ok"] is False
+    assert result["remaining"] == ["20"]
+    assert calls == [False]
+
+
+def test_devtools_extracts_exact_store_package_identity():
+    valid = "AmazonMobileLLC.AmazonMusic_9.5.2.0_x86__kc6t79cpj4tp0"
+    entries = [
+        {"Path": rf"C:\Program Files\WindowsApps\{valid}\Amazon Music Helper.exe"},
+        {"Path": r"C:\Users\user\AppData\Local\Amazon Music\Amazon Music.exe"},
+        {"Path": r"C:\Program Files\WindowsApps\AmazonMobileLLC.AmazonMusic_bad\Amazon Music.exe"},
+    ]
+    assert amazon_devtools._store_package_full_names(entries) == [valid]
+
+
+def test_devtools_store_package_stop_waits_for_full_exit():
+    package = "AmazonMobileLLC.AmazonMusic_9.5.2.0_x86__kc6t79cpj4tp0"
+    helper = {"Pid": 30, "Path": rf"C:\Program Files\WindowsApps\{package}\Amazon Music Helper.exe", "Kind": "helper"}
+    states = [[helper], [], []]
+    terminated = []
+
+    result = amazon_devtools.stop_amazon_store_packages(
+        [package],
+        timeout=2,
+        poll_interval=0.1,
+        process_entries_fn=lambda: states.pop(0) if states else [],
+        terminate_package_fn=terminated.append,
+        sleep_fn=lambda delay: None,
+    )
+    assert result["ok"] is True
+    assert result["stopped"] == ["30"]
+    assert result["packages"] == [package]
+    assert terminated == [package]
+
+
+def test_devtools_restart_uses_store_package_lifecycle_reset(monkeypatch):
+    package = "AmazonMobileLLC.AmazonMusic_9.5.2.0_x86__kc6t79cpj4tp0"
+    entry = {"Pid": 30, "Path": rf"C:\Program Files\WindowsApps\{package}\Amazon Music.exe", "Kind": "main"}
+    reset_calls = []
+    monkeypatch.setattr(amazon_devtools, "_amazon_process_entries", lambda: [entry])
+    monkeypatch.setattr(amazon_devtools, "stop_amazon_music_for_restart", lambda: {"ok": True, "stopped": ["30"]})
+    monkeypatch.setattr(
+        amazon_devtools,
+        "stop_amazon_store_packages",
+        lambda packages: reset_calls.append(packages) or {"ok": True, "stopped": ["31"], "packages": packages},
+    )
+    monkeypatch.setattr(
+        amazon_devtools,
+        "stop_amazon_helpers",
+        lambda: (_ for _ in ()).throw(AssertionError("Store restart must use package lifecycle reset")),
+    )
+    monkeypatch.setattr(amazon_devtools.time, "sleep", lambda delay: None)
+    monkeypatch.setattr(amazon_devtools, "launch_amazon_music_devtools", lambda: {"ok": True, "method": "auto-aumid"})
+    result = amazon_devtools.restart_amazon_music_devtools()
+    assert result["ok"] is True
+    assert result["reset_packages"] == [package]
+    assert reset_calls == [[package]]
+
+
+def test_devtools_helper_stop_handles_respawn_before_launch():
+    helper = {"Pid": 30, "Name": "Amazon Music Helper.exe", "Kind": "helper"}
+    respawned = {"Pid": 31, "Name": "Amazon Music Helper.exe", "Kind": "helper"}
+    states = [[helper], [respawned], [], []]
+    calls = []
+
+    def entries():
+        return states.pop(0) if states else []
+
+    def terminate(items, force):
+        calls.append((force, [entry["Pid"] for entry in items]))
+        return {"ok": True, "stopped": [str(entry["Pid"]) for entry in items], "errors": []}
+
+    result = amazon_devtools.stop_amazon_helpers(
+        timeout=2,
+        poll_interval=0.1,
+        process_entries_fn=entries,
+        terminate_fn=terminate,
+        sleep_fn=lambda delay: None,
+    )
+    assert result["ok"] is True
+    assert result["stopped"] == ["30", "31"]
+    assert calls == [(True, [30]), (True, [31])]
+
+
+def test_devtools_launch_preparation_retires_existing_helpers():
+    main = {"Pid": 20, "Name": "Amazon Music.exe", "Kind": "main"}
+    helper = {"Pid": 21, "Name": "Amazon Music Helper.exe", "Kind": "helper"}
+    running = amazon_devtools._prepare_amazon_launch(process_entries_fn=lambda: [main, helper])
+    delays = []
+    prepared = amazon_devtools._prepare_amazon_launch(
+        process_entries_fn=lambda: [helper],
+        helper_stop_fn=lambda: {"ok": True, "stopped": ["21"], "remaining": [], "errors": []},
+        sleep_fn=delays.append,
+    )
+    assert running["ok"] is False
+    assert running["main_processes"] == ["20"]
+    assert prepared["ok"] is True
+    assert prepared["stale_helpers"] == ["21"]
+    assert prepared["retired_helpers"] == ["21"]
+    assert delays == [amazon_devtools.HELPER_SETTLE_SECONDS]
+
+
+def test_devtools_waits_for_splash_screen_to_clear():
+    states = iter(
+        [
+            {"ready": False, "status": "loading", "detail": "loading"},
+            {"ready": False, "status": "loading", "detail": "loading"},
+            {"ready": True, "status": "ready", "detail": "ready"},
+        ]
+    )
+    result = amazon_devtools._wait_for_app_ready(
+        52856,
+        timeout=1,
+        poll_interval=0.2,
+        boot_state_fn=lambda port: next(states),
+        sleep_fn=lambda delay: None,
+    )
+    assert result["ok"] is True
+    assert result["status"] == "ready"
+
+
+def test_devtools_failed_splash_launch_is_cleaned_up(monkeypatch):
+    class Reservation:
+        def close(self):
+            return None
+
+    amazon_devtools.set_devtools_port(52856)
+    monkeypatch.setattr(amazon_devtools, "_is_local_port_open", lambda port: False)
+    monkeypatch.setattr(amazon_devtools, "_prepare_amazon_launch", lambda: {"ok": True, "stale_helpers": []})
+    monkeypatch.setattr(amazon_devtools, "_reserve_devtools_port", lambda port=None: (52856, Reservation()))
+    monkeypatch.setattr(
+        amazon_devtools,
+        "_launcher_candidates",
+        lambda launcher_override=None: [{"kind": "aumid", "value": "Package.Family!AmazonMusic", "method": "auto-aumid"}],
+    )
+    monkeypatch.setattr(amazon_devtools, "_launch_candidate", lambda candidate, port: {"ok": True, "pid": "44", "activation": "native"})
+    monkeypatch.setattr(amazon_devtools, "_wait_for_page_target", lambda port: True)
+    monkeypatch.setattr(amazon_devtools, "_devtools_owner_trust", lambda *args, **kwargs: {"trusted": True})
+    monkeypatch.setattr(
+        amazon_devtools,
+        "_wait_for_app_ready",
+        lambda port, timeout=amazon_devtools.LAUNCH_READY_TIMEOUT_SECONDS: {
+            "ok": False,
+            "ready": False,
+            "status": "loading",
+            "detail": "Amazon Music remained on its loading screen",
+        },
+    )
+    cleanup_calls = []
+    monkeypatch.setattr(
+        amazon_devtools,
+        "stop_amazon_music",
+        lambda timeout=amazon_devtools.PROCESS_STOP_TIMEOUT_SECONDS: cleanup_calls.append(timeout) or {"ok": True, "stopped": ["44"]},
+    )
+    result = amazon_devtools.launch_amazon_music_devtools()
+    assert result["ok"] is False
+    assert cleanup_calls == [6]
+    assert "loading screen" in result["error"]
+    amazon_devtools.reset_devtools_port()
 
 
 def test_devtools_port_and_powershell_hardening():

--- a/Windows/tests/test_amazon_overlay_security.py
+++ b/Windows/tests/test_amazon_overlay_security.py
@@ -57,3 +57,48 @@ def test_overlay_privacy_action_requires_trusted_user_event(tmp_path):
     )
     assert "api.nextAction" not in script
     assert "consume: function" in script
+
+
+def test_overlay_does_not_attach_during_amazon_splash(monkeypatch, tmp_path):
+    icon = tmp_path / "icon.png"
+    icon.write_bytes(b"icon")
+    overlay = amazon_status_overlay.AmazonStatusOverlay(
+        str(icon),
+        lambda: {},
+        lambda: {},
+        lambda: True,
+        lambda enabled: None,
+    )
+
+    class StopAfterWait:
+        def __init__(self):
+            self.done = False
+
+        def is_set(self):
+            return self.done
+
+        def wait(self, timeout):
+            self.done = True
+
+        def set(self):
+            self.done = True
+
+    overlay._stop_event = StopAfterWait()
+    monkeypatch.setattr(
+        amazon_status_overlay,
+        "_page_target",
+        lambda: {"id": "page", "webSocketDebuggerUrl": "ws://127.0.0.1:52856/devtools/page/page"},
+    )
+    monkeypatch.setattr(amazon_status_overlay, "get_devtools_port", lambda create=False: 52856)
+    monkeypatch.setattr(
+        amazon_status_overlay,
+        "_page_boot_state",
+        lambda port: {"ready": False, "status": "loading", "splash_visible": True},
+    )
+    monkeypatch.setattr(
+        amazon_status_overlay,
+        "_CdpSocket",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Overlay attached during splash")),
+    )
+    overlay._run()
+    assert overlay._client is None

--- a/Windows/tests/test_launcher_diagnostics.py
+++ b/Windows/tests/test_launcher_diagnostics.py
@@ -24,6 +24,12 @@ def test_launcher_failure_advice_prioritises_actionable_next_step():
     assert "does not accept enhanced metadata flags" in message
     assert "Last attempts:" in message
 
+    loading = launcher_diagnostics.format_launcher_failure(
+        ["auto-aumid Package!App: Amazon Music remained on its loading screen"],
+        "Could not launch Amazon Music with enhanced metadata.",
+    )
+    assert "failed helper was closed" in loading
+
 
 def test_pyinstaller_environment_diagnostics_match_updater_cleanup():
     env = {

--- a/Windows/tests/test_media_reader.py
+++ b/Windows/tests/test_media_reader.py
@@ -1,0 +1,11 @@
+# MIT License - Copyright (c) 2026 eripum9
+
+import media_reader
+
+
+def test_smtc_device_not_ready_is_treated_as_no_track(monkeypatch):
+    async def unavailable():
+        raise OSError(-2147024875, "The device is not ready")
+
+    monkeypatch.setattr(media_reader, "get_current_track", unavailable)
+    assert media_reader.get_track_sync(timeout=0.1) is None


### PR DESCRIPTION
## Summary
- prevent the Amazon Music RPC status overlay from attaching while the Store app is still on its startup splash
- close normal Amazon Music sessions gracefully and reset the exact Store package lifecycle before enhanced-metadata relaunches
- clean up failed helpers, preserve actionable launcher diagnostics, and bound SMTC fallback failures
- package the required Qt runtime consistently and bump Windows to v5.0.2

## Root cause
The status overlay opened a second DevTools connection and began a long-running DOM search before Amazon Music's startup renderer was ready. That could deadlock the Store app on its logo. The overlay now waits for validated application readiness before attaching.

## Verification
- 96 Windows tests passed
- 46 built-in self-tests passed
- pyright: 0 errors
- coverage: 50.19% (45% required)
- live normal-launch to native-first enhanced-metadata repair reached Amazon transport successfully
- locally built and installed v5.0.2 passed the same end-to-end repair scenario

Fixes #35