### PR TITLE
Fix Amazon Music overlay startup freeze in v5.0.3

### DIFF
--- a/Windows/amazon_devtools.py
+++ b/Windows/amazon_devtools.py
@@ -32,6 +32,7 @@ AMAZON_EXECUTABLE_NAMES = frozenset({"amazon music.exe", "amazonmusic.exe"})
 AMAZON_HELPER_EXECUTABLE_NAMES = frozenset({"amazon music helper.exe", "amazonmusichelper.exe"})
 LAUNCH_FAILURE_HELP = "Could not launch Amazon Music with enhanced metadata. Open Diagnostics and check the Amazon Music launcher entry, or paste the launcher ID from Get-StartApps."
 LAUNCH_READY_TIMEOUT_SECONDS = 45
+APP_READY_STABLE_POLLS = 3
 PROCESS_STOP_TIMEOUT_SECONDS = 8
 HELPER_SETTLE_SECONDS = 3
 SHORTCUT_NAME = "Amazon Music Metadata.lnk"
@@ -1372,6 +1373,8 @@ class _CdpSocket:
 _BOOT_STATE_EXPRESSION = r"""
 (() => {
   const transport = document.querySelector('#transportContainer.hasTrackLoaded') || document.querySelector('#transportContainer') || document.querySelector('#transport');
+  const navigation = document.querySelector('#appchrome');
+  const main = document.querySelector('main#main-content');
   const splash = document.querySelector('.splashScreen');
   let splashVisible = false;
   if (splash) {
@@ -1380,14 +1383,52 @@ _BOOT_STATE_EXPRESSION = r"""
     const opacity = Number.parseFloat(style.opacity || '1');
     splashVisible = style.display !== 'none' && style.visibility !== 'hidden' && (!Number.isFinite(opacity) || opacity > 0) && rect.width > 0 && rect.height > 0;
   }
+  let mainContentReady = false;
+  let mainTextLength = 0;
+  let mainChildren = 0;
+  if (main) {
+    const style = getComputedStyle(main);
+    const rect = main.getBoundingClientRect();
+    mainTextLength = String(main.innerText || '').replace(/\s+/g, ' ').trim().length;
+    mainChildren = main.children.length;
+    const visible = style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+    mainContentReady = visible && mainChildren > 0 && mainTextLength > 0;
+  }
   return {
     readyState: document.readyState,
     transport: Boolean(transport),
+    navigationReady: Boolean(navigation),
+    mainContentReady,
+    mainTextLength,
+    mainChildren,
     splashVisible,
     bodyChildren: document.body ? document.body.children.length : 0
   };
 })()
 """
+
+
+def _boot_state_result(value):
+    if not isinstance(value, dict):
+        return {"ready": False, "status": "unknown", "detail": "Amazon Music startup state was unavailable"}
+    transport = bool(value.get("transport"))
+    navigation_ready = bool(value.get("navigationReady"))
+    main_content_ready = bool(value.get("mainContentReady"))
+    splash_visible = bool(value.get("splashVisible"))
+    document_ready = value.get("readyState") == "complete"
+    body_ready = int(value.get("bodyChildren") or 0) > 0
+    ready = document_ready and body_ready and navigation_ready and main_content_ready and not splash_visible
+    return {
+        "ready": ready,
+        "status": "ready" if ready else "loading",
+        "detail": "Amazon Music interface is ready" if ready else "Amazon Music remained on its loading screen",
+        "transport": transport,
+        "navigation_ready": navigation_ready,
+        "main_content_ready": main_content_ready,
+        "main_text_length": int(value.get("mainTextLength") or 0),
+        "main_children": int(value.get("mainChildren") or 0),
+        "splash_visible": splash_visible,
+    }
 
 
 def _page_boot_state(port):
@@ -1406,20 +1447,7 @@ def _page_boot_state(port):
             {"expression": _BOOT_STATE_EXPRESSION, "returnByValue": True},
         )
         value = response.get("result", {}).get("result", {}).get("value")
-        if not isinstance(value, dict):
-            return {"ready": False, "status": "unknown", "detail": "Amazon Music startup state was unavailable"}
-        transport = bool(value.get("transport"))
-        splash_visible = bool(value.get("splashVisible"))
-        document_ready = value.get("readyState") == "complete"
-        body_ready = int(value.get("bodyChildren") or 0) > 0
-        ready = transport or (document_ready and body_ready and not splash_visible)
-        return {
-            "ready": ready,
-            "status": "ready" if ready else "loading",
-            "detail": "Amazon Music interface is ready" if ready else "Amazon Music remained on its loading screen",
-            "transport": transport,
-            "splash_visible": splash_visible,
-        }
+        return _boot_state_result(value)
     except Exception as error:
         return {"ready": False, "status": "error", "detail": _clean(error)}
     finally:
@@ -1433,17 +1461,23 @@ def _wait_for_app_ready(
     poll_interval=0.5,
     boot_state_fn=None,
     sleep_fn=None,
+    stable_polls=APP_READY_STABLE_POLLS,
 ):
     state_fn = boot_state_fn or _page_boot_state
     sleeper = sleep_fn or time.sleep
     attempts = max(1, int(max(0.1, timeout) / max(0.05, poll_interval)))
     state = {"ready": False, "status": "loading", "detail": "Amazon Music is loading"}
+    ready_polls = 0
     for _ in range(attempts):
         state = state_fn(port)
         if state.get("ready"):
-            return {"ok": True, **state}
+            ready_polls += 1
+            if ready_polls >= max(1, int(stable_polls)):
+                return {"ok": True, **state, "stable_polls": ready_polls}
+        else:
+            ready_polls = 0
         sleeper(poll_interval)
-    return {"ok": False, **state, "detail": "Amazon Music remained on its loading screen"}
+    return {"ok": False, **state, "stable_polls": ready_polls, "detail": "Amazon Music remained on its loading screen"}
 
 
 _TRANSPORT_EXPRESSION = r"""

--- a/Windows/amazon_devtools.py
+++ b/Windows/amazon_devtools.py
@@ -34,7 +34,6 @@ LAUNCH_FAILURE_HELP = "Could not launch Amazon Music with enhanced metadata. Ope
 LAUNCH_READY_TIMEOUT_SECONDS = 45
 APP_READY_STABLE_POLLS = 3
 PROCESS_STOP_TIMEOUT_SECONDS = 8
-HELPER_SETTLE_SECONDS = 3
 SHORTCUT_NAME = "Amazon Music Metadata.lnk"
 OLD_SHORTCUT_NAMES = ("Amazon Music Beta Metadata.lnk",)
 SHORTCUT_DIR_NAME = "Amazon Music RPC"
@@ -453,9 +452,8 @@ def stop_amazon_helpers(
     }
 
 
-def _prepare_amazon_launch(process_entries_fn=None, helper_stop_fn=None, package_stop_fn=None, sleep_fn=None):
+def _prepare_amazon_launch(process_entries_fn=None):
     entries_fn = process_entries_fn or _amazon_process_entries
-    sleeper = sleep_fn or time.sleep
     entries = entries_fn()
     mains = [entry for entry in entries if _is_main_process(entry)]
     if mains:
@@ -466,32 +464,11 @@ def _prepare_amazon_launch(process_entries_fn=None, helper_stop_fn=None, package
         }
     helpers = [entry for entry in entries if _is_helper_process(entry)]
     helper_ids = [str(_process_id(entry)) for entry in helpers if _process_id(entry)]
-    if not helpers:
-        return {"ok": True, "stale_helpers": [], "retired_helpers": []}
-    package_names = _store_package_full_names(helpers)
-    if package_names and package_stop_fn is None:
-        cleanup = stop_amazon_store_packages(package_names, process_entries_fn=entries_fn)
-    elif package_names:
-        cleanup = package_stop_fn(package_names)
-    elif helper_stop_fn is None:
-        cleanup = stop_amazon_helpers(process_entries_fn=entries_fn)
-    else:
-        cleanup = helper_stop_fn()
-    if not cleanup.get("ok"):
-        return {
-            "ok": False,
-            "error": "Amazon Music Helper could not be prepared for enhanced metadata. End it in Task Manager and try again.",
-            "stale_helpers": helper_ids,
-            "retired_helpers": cleanup.get("stopped", []),
-            "cleanup": cleanup,
-        }
-    sleeper(HELPER_SETTLE_SECONDS)
     return {
         "ok": True,
-        "stale_helpers": helper_ids,
-        "retired_helpers": cleanup.get("stopped", helper_ids),
-        "reset_packages": cleanup.get("packages", []),
-        "cleanup": cleanup,
+        "preserved_helpers": helper_ids,
+        "retired_helpers": [],
+        "reset_packages": [],
     }
 
 
@@ -1762,7 +1739,7 @@ def launch_amazon_music_devtools(launcher_override=None):
                 )
                 if not owner.get("trusted"):
                     attempts.append(f"{_candidate_label(candidate)}: {owner.get('detail')}")
-                    cleanup = stop_amazon_music(timeout=6)
+                    cleanup = stop_amazon_music_for_restart(timeout=6)
                     return {
                         "ok": False,
                         "error": _format_launcher_failure(attempts),
@@ -1773,7 +1750,7 @@ def launch_amazon_music_devtools(launcher_override=None):
                 readiness = _wait_for_app_ready(port)
                 if not readiness.get("ok"):
                     attempts.append(f"{_candidate_label(candidate)}: Amazon Music remained on its loading screen")
-                    cleanup = stop_amazon_music(timeout=6)
+                    cleanup = stop_amazon_music_for_restart(timeout=6)
                     _clear_cache()
                     return {
                         "ok": False,
@@ -1796,7 +1773,7 @@ def launch_amazon_music_devtools(launcher_override=None):
                     "readiness": readiness,
                 }
             attempts.append(f"{_candidate_label(candidate)}: metadata target did not appear")
-            cleanup = stop_amazon_music(timeout=6)
+            cleanup = stop_amazon_music_for_restart(timeout=6)
             if not cleanup.get("ok"):
                 return {
                     "ok": False,
@@ -1832,24 +1809,17 @@ if ($targets.Count -gt 0) {{ "true" }} else {{ "false" }}
 
 
 def restart_amazon_music_devtools():
-    package_names = _store_package_full_names(_amazon_process_entries())
     stop_result = stop_amazon_music_for_restart()
     if not stop_result.get("ok"):
         return stop_result
-    if package_names:
-        cleanup_result = stop_amazon_store_packages(package_names)
-    else:
-        cleanup_result = stop_amazon_helpers()
-    if not cleanup_result.get("ok"):
-        return cleanup_result
     _clear_cache()
-    time.sleep(HELPER_SETTLE_SECONDS)
     launch_result = launch_amazon_music_devtools()
     return {
         **launch_result,
         "stopped": stop_result.get("stopped", []),
-        "retired_helpers": cleanup_result.get("stopped", []),
-        "reset_packages": cleanup_result.get("packages", []),
+        "preserved_helpers": stop_result.get("preserved_helpers", []),
+        "retired_helpers": [],
+        "reset_packages": [],
     }
 
 

--- a/Windows/amazon_devtools.py
+++ b/Windows/amazon_devtools.py
@@ -1458,7 +1458,7 @@ def _wait_for_app_ready(
 
 
 _TRANSPORT_EXPRESSION = r"""
-(async () => {
+(() => {
   const clean = (value) => String(value || '').replace(/\s+/g, ' ').trim();
   const asin = (value) => {
     const text = clean(value).toUpperCase();
@@ -1473,48 +1473,6 @@ _TRANSPORT_EXPRESSION = r"""
     const text = `${location.hash || ''} ${location.search || ''}`;
     const match = text.match(/\/album\/detail\/([A-Z0-9]{10})/i) || text.match(/[?&](?:asin|id)=([A-Z0-9]{10})/i);
     return match ? asin(match[1]) : '';
-  };
-  const queueTrackAsin = async () => {
-    try {
-      const openDb = (name) => new Promise((resolve, reject) => {
-        const request = indexedDB.open(name);
-        request.onerror = () => reject(request.error);
-        request.onsuccess = () => resolve(request.result);
-      });
-      const getAll = (store) => new Promise((resolve, reject) => {
-        const request = store.getAll();
-        request.onerror = () => reject(request.error);
-        request.onsuccess = () => resolve(request.result || []);
-      });
-      const db = await openDb('amplify-datastore');
-      try {
-        if (!db.objectStoreNames.contains('user_DevicePlaybackState') || !db.objectStoreNames.contains('user_QueueSequenceSlice')) {
-          return '';
-        }
-        const transaction = db.transaction(['user_DevicePlaybackState', 'user_QueueSequenceSlice'], 'readonly');
-        const states = await getAll(transaction.objectStore('user_DevicePlaybackState'));
-        const active = states.find((state) => state.playbackState === 'PLAYING') || states.find((state) => state.playbackState === 'PAUSED') || states[0];
-        const reference = asin(active && active.deviceCurrentPlaybackState && active.deviceCurrentPlaybackState.referenceId);
-        if (reference) {
-          return reference;
-        }
-        const queueId = active && active.queueId;
-        const sequenceName = active && active.sequenceName;
-        const sequenceVersion = active && active.sequenceVersion;
-        if (!queueId) {
-          return '';
-        }
-        const slices = (await getAll(transaction.objectStore('user_QueueSequenceSlice')))
-          .filter((slice) => slice.queueId === queueId && (!sequenceName || slice.sequenceName === sequenceName) && (!sequenceVersion || slice.sequenceVersion === sequenceVersion))
-          .sort((left, right) => (left.sliceOrdinal || 0) - (right.sliceOrdinal || 0));
-        const firstReference = slices.flatMap((slice) => slice.entityReferences || []).map((item) => asin(item.identifier)).find(Boolean);
-        return firstReference || '';
-      } finally {
-        db.close();
-      }
-    } catch (_) {
-      return '';
-    }
   };
   const root = document.querySelector('#transportContainer.hasTrackLoaded') || document.querySelector('#transportContainer') || document.querySelector('#transport');
   if (!root) {
@@ -1537,7 +1495,8 @@ _TRANSPORT_EXPRESSION = r"""
   }
   const title = clean((titleEl && (titleEl.getAttribute('title') || titleEl.innerText || titleEl.textContent)) || '');
   const secondary = clean((secondaryEl && (secondaryEl.getAttribute('title') || secondaryEl.innerText || secondaryEl.textContent)) || '');
-  const trackAsin = await queueTrackAsin();
+  const trackMatch = titleLink ? clean(titleLink.href).match(/\/tracks\/([A-Z0-9]{10})(?:[/?#]|$)/i) : null;
+  const trackAsin = trackMatch ? asin(trackMatch[1]) : '';
   return {
     status: title && (secondaryParts[0] || secondary) ? 'found' : 'no_match',
     detail: title ? 'Amazon Music transport found' : 'Amazon Music transport had no title',
@@ -1612,7 +1571,6 @@ def get_devtools_track_sync(link_region=None, port=None, method=""):
         response = client.request("Runtime.evaluate", {
             "expression": _TRANSPORT_EXPRESSION,
             "returnByValue": True,
-            "awaitPromise": True,
             "timeout": 3000,
         })
         result = response.get("result", {}).get("result", {}).get("value")

--- a/Windows/amazon_status_overlay.py
+++ b/Windows/amazon_status_overlay.py
@@ -7,8 +7,7 @@ import threading
 from amazon_devtools import _CdpSocket, _page_boot_state, _page_target, get_devtools_port
 
 
-OVERLAY_VERSION = "2026.09.04.1"
-OVERLAY_WORLD_NAME = "AmazonMusicRPC.StatusOverlay"
+OVERLAY_VERSION = "2026.09.04.2"
 OVERLAY_READY_STABLE_POLLS = 3
 
 
@@ -90,7 +89,7 @@ class AmazonStatusOverlay:
         self._inject_thread = None
         self._stop_event = threading.Event()
         self._client = None
-        self._context_id = None
+        self._api_object_id = None
         self._lock = threading.Lock()
         self._last_error = ""
 
@@ -111,6 +110,7 @@ class AmazonStatusOverlay:
         except Exception:
             pass
         self._client = None
+        self._api_object_id = None
         if self._inject_thread and self._inject_thread is not threading.current_thread():
             self._inject_thread.join(timeout=5)
         self._inject_thread = None
@@ -172,8 +172,7 @@ class AmazonStatusOverlay:
                         expected_port=port,
                         expected_target_id=target.get("id", ""),
                     )
-                    self._context_id = None
-                    self._ensure_isolated_context(self._client)
+                    self._api_object_id = None
                     last_target = target_id
                 if not self._ui_present(self._client):
                     self._inject(self._client)
@@ -190,88 +189,95 @@ class AmazonStatusOverlay:
     def _close_client(self):
         if self._client:
             try:
+                if self._api_object_id:
+                    self._client.request("Runtime.releaseObject", {"objectId": self._api_object_id})
+            except Exception:
+                pass
+            try:
                 self._client.close()
             except Exception:
                 pass
         self._client = None
-        self._context_id = None
+        self._api_object_id = None
 
-    def _ensure_isolated_context(self, client):
-        if self._context_id:
-            return self._context_id
-        client.request("Page.enable")
-        tree = client.request("Page.getFrameTree")
-        frame_id = (
-            tree.get("result", {})
-            .get("frameTree", {})
-            .get("frame", {})
-            .get("id")
-        )
-        if not frame_id:
-            raise RuntimeError("Amazon status overlay could not resolve the main frame")
-        created = client.request(
-            "Page.createIsolatedWorld",
-            {
-                "frameId": frame_id,
-                "worldName": OVERLAY_WORLD_NAME,
-                "grantUniveralAccess": False,
-            },
-        )
-        self._context_id = created.get("result", {}).get("executionContextId")
-        if not self._context_id:
-            raise RuntimeError("Amazon status overlay could not create an isolated world")
-        return self._context_id
-
-    def _evaluate(self, client, expression, await_promise=False):
+    def _evaluate(self, client, expression, await_promise=False, return_by_value=True):
         params = {
             "expression": expression,
-            "returnByValue": True,
-            "contextId": self._ensure_isolated_context(client),
+            "returnByValue": return_by_value,
         }
         if await_promise:
             params["awaitPromise"] = True
         return client.request("Runtime.evaluate", params)
 
-    def _ui_present(self, client):
-        expression = (
-            "Boolean(document.getElementById('amrpc-status-button') "
-            "&& window.__amrpcStatusOverlay "
-            f"&& window.__amrpcStatusOverlay.version === {json.dumps(OVERLAY_VERSION)})"
+    def _call_api(self, client, function_declaration, arguments=None):
+        if not self._api_object_id:
+            raise RuntimeError("Amazon status overlay API is unavailable")
+        return client.request(
+            "Runtime.callFunctionOn",
+            {
+                "objectId": self._api_object_id,
+                "functionDeclaration": function_declaration,
+                "arguments": arguments or [],
+                "returnByValue": True,
+            },
         )
-        response = self._evaluate(client, expression)
+
+    def _ui_present(self, client):
+        if not self._api_object_id:
+            return False
+        response = self._call_api(
+            client,
+            "function(expectedVersion){return Boolean(this.version===expectedVersion && document.getElementById('amrpc-status-button') && document.getElementById('amrpc-status-menu'));}",
+            [{"value": OVERLAY_VERSION}],
+        )
         return bool(response.get("result", {}).get("result", {}).get("value"))
 
     def _remove_ui(self, client):
-        self._evaluate(
-            client,
-            "if(window.__amrpcStatusOverlay&&window.__amrpcStatusOverlay.stop)window.__amrpcStatusOverlay.stop();['amrpc-status-button','amrpc-status-menu','amrpc-status-style'].forEach(function(id){var node=document.getElementById(id);if(node&&node.parentElement)node.parentElement.removeChild(node);});delete window.__amrpcStatusOverlay;",
-        )
+        if self._api_object_id:
+            try:
+                self._call_api(client, "function(){if(this.stop)this.stop();return true;}")
+            except Exception:
+                pass
+        self._evaluate(client, "['amrpc-status-button','amrpc-status-menu','amrpc-status-style'].forEach(function(id){var node=document.getElementById(id);if(node&&node.parentElement)node.parentElement.removeChild(node);});")
 
     def _consume_action(self, client):
-        response = self._evaluate(
-            client,
-            "(function(){var api=window.__amrpcStatusOverlay;return api&&api.consume?api.consume():null;})()",
-        )
+        response = self._call_api(client, "function(){return this.consume?this.consume():null;}")
         action = response.get("result", {}).get("result", {}).get("value")
         if isinstance(action, dict) and action.get("type") == "privacy":
             self.apply_privacy(bool(action.get("enabled")))
 
     def _push_payload(self, client):
-        payload = json.dumps(self.payload())
-        self._evaluate(
+        self._call_api(
             client,
-            f"(function(data){{if(window.__amrpcStatusOverlay&&window.__amrpcStatusOverlay.render)window.__amrpcStatusOverlay.render(data);}})({payload})",
+            "function(data){if(this.render)this.render(data);return true;}",
+            [{"value": self.payload()}],
         )
 
     def _inject(self, client):
+        # Amazon Music 9.5.2 freezes playback when CDP creates an isolated world.
+        # Keep the API private by retaining only its remote object handle here.
+        if self._api_object_id:
+            self._remove_ui(client)
+            try:
+                client.request("Runtime.releaseObject", {"objectId": self._api_object_id})
+            except Exception:
+                pass
+            self._api_object_id = None
         script = self._script()
-        response = self._evaluate(client, script, await_promise=True)
+        response = self._evaluate(client, script, await_promise=True, return_by_value=False)
         result = response.get("result", {}).get("result", {})
         if result.get("subtype") == "error":
             raise RuntimeError(result.get("description") or "Amazon status overlay injection failed")
-        value = result.get("value")
-        if isinstance(value, dict) and not value.get("ok", False):
-            raise RuntimeError(value.get("reason") or "Amazon status overlay injection failed")
+        self._api_object_id = result.get("objectId")
+        if not self._api_object_id:
+            raise RuntimeError("Amazon status overlay did not return a private API handle")
+        probe = self._call_api(
+            client,
+            "function(){return {ok:Boolean(this.ok),reason:this.reason||'',version:this.version||''};}",
+        )
+        value = probe.get("result", {}).get("result", {}).get("value")
+        if not isinstance(value, dict) or not value.get("ok", False):
+            raise RuntimeError((value or {}).get("reason") or "Amazon status overlay injection failed")
 
     def _script(self):
         icon_src = _image_data_url(self.icon_path)
@@ -434,24 +440,36 @@ class AmazonStatusOverlay:
     nextAction = {{ type: 'privacy', enabled: !!toggle.checked, at: Date.now() }};
   }}, true);
   menu.addEventListener('click', function (event) {{ event.stopPropagation(); }});
-  document.addEventListener('click', function (event) {{
+  var closeMenuOnOutsideClick = function (event) {{
     if (!menu.hidden && !menu.contains(event.target) && !button.contains(event.target)) closeMenu();
-  }});
-  window.addEventListener('resize', function () {{
+  }};
+  var repositionOverlay = function () {{
     if (menu.hidden) positionButton();
     else positionMenu();
-  }});
-  window.__amrpcStatusOverlay = {{
+  }};
+  document.addEventListener('click', closeMenuOnOutsideClick);
+  window.addEventListener('resize', repositionOverlay);
+  var api = {{
+    ok: true,
     version: overlayVersion,
     render: render,
     open: openMenu,
     close: closeMenu,
-    stop: closeMenu,
+    stop: function () {{
+      closeMenu();
+      document.removeEventListener('click', closeMenuOnOutsideClick);
+      window.removeEventListener('resize', repositionOverlay);
+      [button, menu, style].forEach(function (node) {{
+        if (node && node.parentElement) node.parentElement.removeChild(node);
+      }});
+    }},
     consume: function () {{ var action = nextAction; nextAction = null; return action; }}
   }};
   positionButton();
   render(initialData);
   var rect = button.getBoundingClientRect();
-  return {{ ok: true, text: label.textContent, rect: {{ x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) }} }};
+  api.text = label.textContent;
+  api.rect = {{ x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) }};
+  return api;
 }})()
 """

--- a/Windows/amazon_status_overlay.py
+++ b/Windows/amazon_status_overlay.py
@@ -7,8 +7,9 @@ import threading
 from amazon_devtools import _CdpSocket, _page_boot_state, _page_target, get_devtools_port
 
 
-OVERLAY_VERSION = "2026.07.16.1"
+OVERLAY_VERSION = "2026.09.04.1"
 OVERLAY_WORLD_NAME = "AmazonMusicRPC.StatusOverlay"
+OVERLAY_READY_STABLE_POLLS = 3
 
 
 def _clean(value):
@@ -135,20 +136,34 @@ class AmazonStatusOverlay:
 
     def _run(self):
         last_target = None
+        ready_target = None
+        ready_polls = 0
         while not self._stop_event.is_set():
             try:
                 target = _page_target()
                 if not target:
                     self._close_client()
+                    ready_target = None
+                    ready_polls = 0
                     self._stop_event.wait(2)
                     continue
                 port = get_devtools_port(False)
                 readiness = _page_boot_state(port) if port else {"ready": False}
+                target_id = target.get("id") or target.get("webSocketDebuggerUrl")
                 if not readiness.get("ready"):
                     self._close_client()
+                    ready_target = None
+                    ready_polls = 0
                     self._stop_event.wait(1)
                     continue
-                target_id = target.get("id") or target.get("webSocketDebuggerUrl")
+                if target_id != ready_target:
+                    ready_target = target_id
+                    ready_polls = 1
+                else:
+                    ready_polls += 1
+                if ready_polls < OVERLAY_READY_STABLE_POLLS:
+                    self._stop_event.wait(1)
+                    continue
                 if not self._client or target_id != last_target:
                     self._close_client()
                     self._client = _CdpSocket(
@@ -168,6 +183,8 @@ class AmazonStatusOverlay:
             except Exception as e:
                 self._last_error = str(e)
                 self._close_client()
+                ready_target = None
+                ready_polls = 0
                 self._stop_event.wait(3)
 
     def _close_client(self):
@@ -273,8 +290,7 @@ class AmazonStatusOverlay:
   }}
   if (!input) return {{ ok: false, reason: 'search input not found' }};
   var searchContainer = input.closest('.searchBarContainer') || input.closest('.searchBar') || input.parentElement;
-  var parent = searchContainer && searchContainer.parentElement;
-  if (!searchContainer || !parent) return {{ ok: false, reason: 'search container not found' }};
+  if (!searchContainer) return {{ ok: false, reason: 'search container not found' }};
   ['amrpc-status-button', 'amrpc-status-menu', 'amrpc-status-style'].forEach(function (id) {{
     var node = document.getElementById(id);
     if (node && node.parentElement) node.parentElement.removeChild(node);
@@ -287,7 +303,7 @@ class AmazonStatusOverlay:
       background: rgba(30, 215, 96, .95); color: #08120c; display: inline-flex; align-items: center;
       justify-content: center; gap: 7px; font: 800 12px/1 "Segoe UI", sans-serif; letter-spacing: 0;
       white-space: nowrap; cursor: pointer; box-shadow: 0 0 0 1px rgba(255,255,255,.16), 0 8px 22px rgba(0,0,0,.28);
-      position: relative; z-index: 80;
+      position: fixed; z-index: 1000000;
     }}
     #amrpc-status-button[data-tone="private"] {{ background: rgba(88, 101, 242, .96); color: #fff; }}
     #amrpc-status-button[data-tone="paused"] {{ background: rgba(255, 209, 102, .96); color: #17110a; }}
@@ -338,10 +354,8 @@ class AmazonStatusOverlay:
     </div>
     <div class="amrpc-diag"><div class="amrpc-diag-title">Mini diagnostics</div><div id="amrpc-diag-list"></div></div>
   `;
+  document.body.appendChild(button);
   document.body.appendChild(menu);
-  parent.style.display = 'flex';
-  parent.style.alignItems = 'center';
-  parent.insertBefore(button, searchContainer);
   var label = button.querySelector('#amrpc-status-label');
   var pill = menu.querySelector('#amrpc-menu-pill');
   var toggle = menu.querySelector('#amrpc-privacy-toggle');
@@ -359,7 +373,15 @@ class AmazonStatusOverlay:
     toggle.disabled = privacyBusy;
     toggleShell.dataset.busy = privacyBusy ? '1' : '0';
   }};
+  var positionButton = function () {{
+    var searchRect = searchContainer.getBoundingClientRect();
+    var width = button.offsetWidth || 98;
+    var top = searchRect.top + Math.max(0, (searchRect.height - 36) / 2);
+    button.style.top = Math.max(8, Math.round(top)) + 'px';
+    button.style.left = Math.max(12, Math.round(searchRect.left - width - 10)) + 'px';
+  }};
   var positionMenu = function () {{
+    positionButton();
     var rect = button.getBoundingClientRect();
     menu.style.top = Math.round(rect.bottom + 8) + 'px';
     menu.style.right = Math.max(12, Math.round(window.innerWidth - rect.right)) + 'px';
@@ -374,6 +396,7 @@ class AmazonStatusOverlay:
     diagList.innerHTML = (data.diagnostics || []).map(function (row) {{
       return '<div class="amrpc-diag-row" data-state="' + escapeHtml(row.state || 'ok') + '"><span><i class="amrpc-dot"></i>' + escapeHtml(row.label) + '</span><strong>' + escapeHtml(row.value) + '</strong></div>';
     }}).join('');
+    positionButton();
   }};
   var openMenu = function () {{
     positionMenu();
@@ -414,7 +437,10 @@ class AmazonStatusOverlay:
   document.addEventListener('click', function (event) {{
     if (!menu.hidden && !menu.contains(event.target) && !button.contains(event.target)) closeMenu();
   }});
-  window.addEventListener('resize', positionMenu);
+  window.addEventListener('resize', function () {{
+    if (menu.hidden) positionButton();
+    else positionMenu();
+  }});
   window.__amrpcStatusOverlay = {{
     version: overlayVersion,
     render: render,
@@ -423,6 +449,7 @@ class AmazonStatusOverlay:
     stop: closeMenu,
     consume: function () {{ var action = nextAction; nextAction = null; return action; }}
   }};
+  positionButton();
   render(initialData);
   var rect = button.getBoundingClientRect();
   return {{ ok: true, text: label.textContent, rect: {{ x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) }} }};

--- a/Windows/config.py
+++ b/Windows/config.py
@@ -27,7 +27,7 @@ if not os.environ.get("APPDATA") or getattr(sys, "frozen", False) is False:
     CONFIG_DIR = os.path.dirname(os.path.abspath(__file__))
     CONFIG_PATH = os.path.join(CONFIG_DIR, "config.json")
 
-APP_VERSION = "5.0.2"
+APP_VERSION = "5.0.3"
 AMAZON_MUSIC_LINK_REGIONS = (
     "com",
     "de",

--- a/Windows/installer.iss
+++ b/Windows/installer.iss
@@ -1,5 +1,5 @@
 #define MyAppName "Amazon Music RPC"
-#define MyAppVersion "5.0.2"
+#define MyAppVersion "5.0.3"
 #define MyAppPublisher "PumpgunStudios"
 #define MyAppExeName "AmazonMusicRPC.exe"
 

--- a/Windows/self_tests.py
+++ b/Windows/self_tests.py
@@ -886,6 +886,9 @@ def run_self_tests(log_dir, diagnostics_path):
             and incomplete.get("status") == "no_match"
             and all(fragment in sample_html for fragment in ("trackMetadataWrapper", "secondaryInnerText", "artImage", "currentPlaybackPosition", "currentRemainingPosition", "playPause"))
             and all(selector in _TRANSPORT_EXPRESSION for selector in selectors)
+            and "indexedDB" not in _TRANSPORT_EXPRESSION
+            and "user_DevicePlaybackState" not in _TRANSPORT_EXPRESSION
+            and "user_QueueSequenceSlice" not in _TRANSPORT_EXPRESSION
         )
         results.append(_result("Amazon DevTools fragile payloads", ok, "Sample DOM shape, selectors, explicit cleanup, pause state, missing art, and one-letter album cases are covered"))
     except Exception as e:

--- a/Windows/tests/test_amazon_devtools.py
+++ b/Windows/tests/test_amazon_devtools.py
@@ -44,6 +44,14 @@ def test_devtools_single_secondary_label_populates_artist():
     assert payload["album"] == ""
 
 
+def test_devtools_transport_probe_is_dom_only():
+    expression = amazon_devtools._TRANSPORT_EXPRESSION
+    assert "indexedDB" not in expression
+    assert "user_DevicePlaybackState" not in expression
+    assert "user_QueueSequenceSlice" not in expression
+    assert "titleLink.href" in expression
+
+
 def test_devtools_target_validation_and_search_links():
     good_target = {
         "type": "page",

--- a/Windows/tests/test_amazon_devtools.py
+++ b/Windows/tests/test_amazon_devtools.py
@@ -248,28 +248,30 @@ def test_devtools_store_package_stop_waits_for_full_exit():
     assert terminated == [package]
 
 
-def test_devtools_restart_uses_store_package_lifecycle_reset(monkeypatch):
+def test_devtools_restart_preserves_helper_and_skips_package_reset(monkeypatch):
     package = "AmazonMobileLLC.AmazonMusic_9.5.2.0_x86__kc6t79cpj4tp0"
-    entry = {"Pid": 30, "Path": rf"C:\Program Files\WindowsApps\{package}\Amazon Music.exe", "Kind": "main"}
-    reset_calls = []
-    monkeypatch.setattr(amazon_devtools, "_amazon_process_entries", lambda: [entry])
-    monkeypatch.setattr(amazon_devtools, "stop_amazon_music_for_restart", lambda: {"ok": True, "stopped": ["30"]})
+    helper = {"Pid": 31, "Path": rf"C:\Program Files\WindowsApps\{package}\Amazon Music Helper.exe", "Kind": "helper"}
+    monkeypatch.setattr(
+        amazon_devtools,
+        "stop_amazon_music_for_restart",
+        lambda: {"ok": True, "stopped": ["30"], "preserved_helpers": ["31"]},
+    )
     monkeypatch.setattr(
         amazon_devtools,
         "stop_amazon_store_packages",
-        lambda packages: reset_calls.append(packages) or {"ok": True, "stopped": ["31"], "packages": packages},
+        lambda packages: (_ for _ in ()).throw(AssertionError("Restart must preserve the Store package lifecycle")),
     )
     monkeypatch.setattr(
         amazon_devtools,
         "stop_amazon_helpers",
-        lambda: (_ for _ in ()).throw(AssertionError("Store restart must use package lifecycle reset")),
+        lambda: (_ for _ in ()).throw(AssertionError("Restart must preserve Amazon Music Helper")),
     )
-    monkeypatch.setattr(amazon_devtools.time, "sleep", lambda delay: None)
     monkeypatch.setattr(amazon_devtools, "launch_amazon_music_devtools", lambda: {"ok": True, "method": "auto-aumid"})
     result = amazon_devtools.restart_amazon_music_devtools()
     assert result["ok"] is True
-    assert result["reset_packages"] == [package]
-    assert reset_calls == [[package]]
+    assert result["preserved_helpers"] == [str(helper["Pid"])]
+    assert result["retired_helpers"] == []
+    assert result["reset_packages"] == []
 
 
 def test_devtools_helper_stop_handles_respawn_before_launch():
@@ -297,22 +299,17 @@ def test_devtools_helper_stop_handles_respawn_before_launch():
     assert calls == [(True, [30]), (True, [31])]
 
 
-def test_devtools_launch_preparation_retires_existing_helpers():
+def test_devtools_launch_preparation_preserves_existing_helpers():
     main = {"Pid": 20, "Name": "Amazon Music.exe", "Kind": "main"}
     helper = {"Pid": 21, "Name": "Amazon Music Helper.exe", "Kind": "helper"}
     running = amazon_devtools._prepare_amazon_launch(process_entries_fn=lambda: [main, helper])
-    delays = []
-    prepared = amazon_devtools._prepare_amazon_launch(
-        process_entries_fn=lambda: [helper],
-        helper_stop_fn=lambda: {"ok": True, "stopped": ["21"], "remaining": [], "errors": []},
-        sleep_fn=delays.append,
-    )
+    prepared = amazon_devtools._prepare_amazon_launch(process_entries_fn=lambda: [helper])
     assert running["ok"] is False
     assert running["main_processes"] == ["20"]
     assert prepared["ok"] is True
-    assert prepared["stale_helpers"] == ["21"]
-    assert prepared["retired_helpers"] == ["21"]
-    assert delays == [amazon_devtools.HELPER_SETTLE_SECONDS]
+    assert prepared["preserved_helpers"] == ["21"]
+    assert prepared["retired_helpers"] == []
+    assert prepared["reset_packages"] == []
 
 
 def test_devtools_waits_for_splash_screen_to_clear():
@@ -418,7 +415,7 @@ def test_devtools_failed_splash_launch_is_cleaned_up(monkeypatch):
     cleanup_calls = []
     monkeypatch.setattr(
         amazon_devtools,
-        "stop_amazon_music",
+        "stop_amazon_music_for_restart",
         lambda timeout=amazon_devtools.PROCESS_STOP_TIMEOUT_SECONDS: cleanup_calls.append(timeout) or {"ok": True, "stopped": ["44"]},
     )
     result = amazon_devtools.launch_amazon_music_devtools()

--- a/Windows/tests/test_amazon_devtools.py
+++ b/Windows/tests/test_amazon_devtools.py
@@ -321,6 +321,8 @@ def test_devtools_waits_for_splash_screen_to_clear():
             {"ready": False, "status": "loading", "detail": "loading"},
             {"ready": False, "status": "loading", "detail": "loading"},
             {"ready": True, "status": "ready", "detail": "ready"},
+            {"ready": True, "status": "ready", "detail": "ready"},
+            {"ready": True, "status": "ready", "detail": "ready"},
         ]
     )
     result = amazon_devtools._wait_for_app_ready(
@@ -332,6 +334,58 @@ def test_devtools_waits_for_splash_screen_to_clear():
     )
     assert result["ok"] is True
     assert result["status"] == "ready"
+    assert result["stable_polls"] == amazon_devtools.APP_READY_STABLE_POLLS
+
+
+def test_devtools_transport_shell_is_not_enough_for_app_readiness():
+    loading = amazon_devtools._boot_state_result(
+        {
+            "readyState": "complete",
+            "transport": True,
+            "navigationReady": True,
+            "mainContentReady": False,
+            "mainTextLength": 0,
+            "mainChildren": 0,
+            "splashVisible": False,
+            "bodyChildren": 4,
+        }
+    )
+    ready = amazon_devtools._boot_state_result(
+        {
+            "readyState": "complete",
+            "transport": True,
+            "navigationReady": True,
+            "mainContentReady": True,
+            "mainTextLength": 120,
+            "mainChildren": 2,
+            "splashVisible": False,
+            "bodyChildren": 4,
+        }
+    )
+    assert loading["ready"] is False
+    assert ready["ready"] is True
+
+
+def test_devtools_readiness_stability_resets_after_loading_state():
+    states = iter(
+        [
+            {"ready": True, "status": "ready", "detail": "ready"},
+            {"ready": True, "status": "ready", "detail": "ready"},
+            {"ready": False, "status": "loading", "detail": "loading"},
+            {"ready": True, "status": "ready", "detail": "ready"},
+            {"ready": True, "status": "ready", "detail": "ready"},
+            {"ready": True, "status": "ready", "detail": "ready"},
+        ]
+    )
+    result = amazon_devtools._wait_for_app_ready(
+        52856,
+        timeout=2,
+        poll_interval=0.2,
+        boot_state_fn=lambda port: next(states),
+        sleep_fn=lambda delay: None,
+    )
+    assert result["ok"] is True
+    assert result["stable_polls"] == amazon_devtools.APP_READY_STABLE_POLLS
 
 
 def test_devtools_failed_splash_launch_is_cleaned_up(monkeypatch):

--- a/Windows/tests/test_amazon_overlay_security.py
+++ b/Windows/tests/test_amazon_overlay_security.py
@@ -1,7 +1,5 @@
 # MIT License - Copyright (c) 2026 eripum9
 
-import inspect
-
 import amazon_status_overlay
 
 
@@ -11,14 +9,14 @@ class FakeClient:
 
     def request(self, method, params=None):
         self.calls.append((method, params or {}))
-        if method == "Page.getFrameTree":
-            return {"result": {"frameTree": {"frame": {"id": "main-frame"}}}}
-        if method == "Page.createIsolatedWorld":
-            return {"result": {"executionContextId": 73}}
+        if method == "Runtime.evaluate" and not (params or {}).get("returnByValue", True):
+            return {"result": {"result": {"objectId": "overlay-api"}}}
+        if method == "Runtime.callFunctionOn" and "Boolean(this.ok)" in (params or {}).get("functionDeclaration", ""):
+            return {"result": {"result": {"value": {"ok": True, "version": amazon_status_overlay.OVERLAY_VERSION}}}}
         return {"result": {"result": {"value": True}}}
 
 
-def test_overlay_evaluates_only_in_isolated_world(tmp_path):
+def test_overlay_uses_private_main_world_object_without_isolated_world(tmp_path):
     icon = tmp_path / "icon.png"
     icon.write_bytes(b"icon")
     overlay = amazon_status_overlay.AmazonStatusOverlay(
@@ -29,15 +27,13 @@ def test_overlay_evaluates_only_in_isolated_world(tmp_path):
         lambda enabled: None,
     )
     client = FakeClient()
-    overlay._evaluate(client, "1 + 1")
-    create = next(params for method, params in client.calls if method == "Page.createIsolatedWorld")
+    overlay._inject(client)
     evaluate = next(params for method, params in client.calls if method == "Runtime.evaluate")
-    assert create == {
-        "frameId": "main-frame",
-        "worldName": amazon_status_overlay.OVERLAY_WORLD_NAME,
-        "grantUniveralAccess": False,
-    }
-    assert evaluate["contextId"] == 73
+    assert evaluate["returnByValue"] is False
+    assert "contextId" not in evaluate
+    assert overlay._api_object_id == "overlay-api"
+    assert all(method not in {"Page.enable", "Page.createIsolatedWorld"} for method, _ in client.calls)
+    assert any(method == "Runtime.callFunctionOn" for method, _ in client.calls)
 
 
 def test_overlay_privacy_action_requires_trusted_user_event(tmp_path):
@@ -52,9 +48,7 @@ def test_overlay_privacy_action_requires_trusted_user_event(tmp_path):
     )
     script = overlay._script()
     assert "event.isTrusted" in script
-    assert "Page.createIsolatedWorld" in inspect.getsource(
-        amazon_status_overlay.AmazonStatusOverlay._ensure_isolated_context
-    )
+    assert "window.__amrpcStatusOverlay" not in script
     assert "api.nextAction" not in script
     assert "consume: function" in script
 

--- a/Windows/tests/test_amazon_overlay_security.py
+++ b/Windows/tests/test_amazon_overlay_security.py
@@ -59,6 +59,23 @@ def test_overlay_privacy_action_requires_trusted_user_event(tmp_path):
     assert "consume: function" in script
 
 
+def test_overlay_mounts_outside_amazon_owned_layout(tmp_path):
+    icon = tmp_path / "icon.png"
+    icon.write_bytes(b"icon")
+    overlay = amazon_status_overlay.AmazonStatusOverlay(
+        str(icon),
+        lambda: {},
+        lambda: {},
+        lambda: True,
+        lambda enabled: None,
+    )
+    script = overlay._script()
+    assert "document.body.appendChild(button)" in script
+    assert "position: fixed" in script
+    assert "parent.style" not in script
+    assert "parent.insertBefore" not in script
+
+
 def test_overlay_does_not_attach_during_amazon_splash(monkeypatch, tmp_path):
     icon = tmp_path / "icon.png"
     icon.write_bytes(b"icon")
@@ -102,3 +119,54 @@ def test_overlay_does_not_attach_during_amazon_splash(monkeypatch, tmp_path):
     )
     overlay._run()
     assert overlay._client is None
+
+
+def test_overlay_requires_stable_ready_page_before_attach(monkeypatch, tmp_path):
+    icon = tmp_path / "icon.png"
+    icon.write_bytes(b"icon")
+    overlay = amazon_status_overlay.AmazonStatusOverlay(
+        str(icon),
+        lambda: {},
+        lambda: {},
+        lambda: True,
+        lambda enabled: None,
+    )
+
+    class StopAfterWaits:
+        def __init__(self, limit):
+            self.limit = limit
+            self.waits = 0
+
+        def is_set(self):
+            return self.waits >= self.limit
+
+        def wait(self, timeout):
+            self.waits += 1
+
+        def set(self):
+            self.waits = self.limit
+
+    created = []
+
+    def create_client(*args, **kwargs):
+        client = FakeClient()
+        created.append((overlay._stop_event.waits, client))
+        return client
+
+    overlay._stop_event = StopAfterWaits(amazon_status_overlay.OVERLAY_READY_STABLE_POLLS)
+    monkeypatch.setattr(
+        amazon_status_overlay,
+        "_page_target",
+        lambda: {"id": "page", "webSocketDebuggerUrl": "ws://127.0.0.1:52856/devtools/page/page"},
+    )
+    monkeypatch.setattr(amazon_status_overlay, "get_devtools_port", lambda create=False: 52856)
+    monkeypatch.setattr(
+        amazon_status_overlay,
+        "_page_boot_state",
+        lambda port: {"ready": True, "status": "ready", "splash_visible": False},
+    )
+    monkeypatch.setattr(amazon_status_overlay, "_CdpSocket", create_client)
+    overlay._run()
+    assert len(created) == 1
+    assert created[0][0] == amazon_status_overlay.OVERLAY_READY_STABLE_POLLS - 1
+    assert overlay._client is created[0][1]


### PR DESCRIPTION
## Summary
- stop creating a CDP isolated world for the standalone Amazon Music status overlay
- keep the overlay API private through a retained CDP remote-object handle instead of exposing it on `window`
- keep recurring enhanced-metadata polling read-only at the visible transport DOM layer
- preserve Amazon Music Helper and the Microsoft Store package lifecycle during enhanced-metadata launch
- require Amazon Music's populated main view to remain ready across consecutive checks before attaching the overlay
- mount the overlay independently instead of changing Amazon-owned header layout
- bump the Windows app and installer version to v5.0.3
- add regression coverage for the private overlay handle, trusted privacy actions, DOM-only polling, lifecycle preservation, and readiness gating

## Root cause
Controlled testing isolated the playback failure to `Page.createIsolatedWorld`. On Amazon Music 9.5.2, creating an isolated CDP execution world immediately freezes the player: the timer stops, transport controls stop responding, track changes fail, and output-device selection becomes unusable. This reproduced even when no overlay DOM, styles, listeners, or metadata polling were injected.

The Store AUMID launcher and DOM-only metadata polling both passed independent playback tests. Amazify works because it evaluates its plugin runtime in Amazon Music's main world and does not create an isolated CDP world.

The standalone overlay now evaluates in the main world but returns its API as a private remote object. Native code stores only the CDP `objectId` and invokes it with `Runtime.callFunctionOn`; the API is never assigned to `window`, so ordinary Amazon page scripts cannot directly issue RPC privacy commands.

The earlier launcher-lifecycle, readiness, and DOM-only polling changes remain useful hardening, but they were not the direct playback-freeze trigger.

## Validation
- 28 focused overlay and DevTools tests passed on Python 3.12
- `git diff --check` passed
- source-mode Amazon Music 9.5.2 test passed: playback, pause/resume, Next, timer progression, and output-device switching while the overlay remained attached
- PyInstaller and Inno Setup builds completed successfully
- installed v5.0.3 cold-start test passed: overlay visible, metadata found, Discord connected, track change, pause/resume, and timer progression
- full Windows tests are left to GitHub Actions

Fixes #40